### PR TITLE
Characterize recursive load readiness defects

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible class based database system for complicated schemas",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test test/load-readiness.test.cjs"
   },
   "keywords": [
     "database",

--- a/test/fixtures/detached-load-failure-worker.cjs
+++ b/test/fixtures/detached-load-failure-worker.cjs
@@ -1,0 +1,124 @@
+'use strict';
+
+const { writeFileSync } = require('node:fs');
+const path = require('node:path');
+
+const Moxley = require('../..');
+
+const DETACHED_REJECTION_TIMEOUT_MS = 5_000;
+
+function errorName(error) {
+  if (error && typeof error.name === 'string') {
+    return error.name;
+  }
+  return typeof error;
+}
+
+function emit(payload) {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+function waitForDetachedRejection(promise) {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      resolve(false);
+    }, DETACHED_REJECTION_TIMEOUT_MS);
+
+    promise.then(() => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
+
+async function main() {
+  const testDirectory = process.argv[2];
+  if (!testDirectory || !path.isAbsolute(testDirectory)) {
+    throw new TypeError('worker requires an absolute test directory');
+  }
+
+  const databaseDirectory = path.join(testDirectory, 'database');
+  const databasePath = `${databaseDirectory}${path.sep}`;
+  const seeded = new Moxley(databasePath);
+  seeded.db._create('descendant');
+  writeFileSync(
+    path.join(databaseDirectory, '0', '_state.ms'),
+    'malformed descendant state',
+  );
+
+  const reopened = new Moxley(databasePath);
+  const root = reopened.db;
+  let outerStatus = 'pending';
+  let outerResolvedBeforeDetachedRejection = false;
+  const detachedRejections = [];
+  let resolveDetachedRejection;
+  const detachedRejection = new Promise((resolve) => {
+    resolveDetachedRejection = resolve;
+  });
+  const onUnhandledRejection = (error) => {
+    outerResolvedBeforeDetachedRejection = outerStatus === 'resolved';
+    detachedRejections.push({ name: errorName(error) });
+    resolveDetachedRejection();
+  };
+
+  process.on('unhandledRejection', onUnhandledRejection);
+
+  try {
+    const outerResult = await root._loadFromDir().then(
+      (value) => {
+        outerStatus = 'resolved';
+        return {
+          status: outerStatus,
+          returnedSameRoot: value === root,
+        };
+      },
+      (error) => {
+        outerStatus = 'rejected';
+        return {
+          status: outerStatus,
+          errorName: errorName(error),
+        };
+      },
+    );
+
+    if (outerResult.status !== 'resolved') {
+      emit({
+        status: 'outer-rejected',
+        outerStatus,
+        errorName: outerResult.errorName,
+      });
+      process.exitCode = 2;
+      return;
+    }
+
+    const observed = await waitForDetachedRejection(detachedRejection);
+    if (!observed) {
+      emit({
+        status: 'timeout',
+        outerStatus,
+        returnedSameRoot: outerResult.returnedSameRoot,
+      });
+      process.exitCode = 3;
+      return;
+    }
+
+    await new Promise((resolve) => setImmediate(resolve));
+    emit({
+      status: 'characterized',
+      outerStatus,
+      returnedSameRoot: outerResult.returnedSameRoot,
+      outerResolvedBeforeDetachedRejection,
+      detachedRejections,
+    });
+  } finally {
+    process.removeListener('unhandledRejection', onUnhandledRejection);
+  }
+}
+
+main().catch((error) => {
+  emit({
+    status: 'unexpected-failure',
+    errorName: errorName(error),
+  });
+  process.exitCode = 1;
+});

--- a/test/load-readiness.test.cjs
+++ b/test/load-readiness.test.cjs
@@ -1,0 +1,249 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const { mkdtemp, rm } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const Moxley = require('..');
+
+const WORKER_PATH = path.join(
+  __dirname,
+  'fixtures',
+  'detached-load-failure-worker.cjs',
+);
+const SYNCHRONIZATION_TIMEOUT_MS = 5_000;
+const CHILD_PROCESS_TIMEOUT_MS = 10_000;
+
+function createDeferred() {
+  let resolvePromise;
+  let rejectPromise;
+  let settled = false;
+  const promise = new Promise((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    get settled() {
+      return settled;
+    },
+    resolve(value) {
+      if (!settled) {
+        settled = true;
+        resolvePromise(value);
+      }
+    },
+    reject(error) {
+      if (!settled) {
+        settled = true;
+        rejectPromise(error);
+      }
+    },
+  };
+}
+
+function withTimeout(promise, label, timeoutMs = SYNCHRONIZATION_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function createTestDirectory(t) {
+  const testDirectory = await mkdtemp(
+    path.join(os.tmpdir(), 'moxley-load-readiness-'),
+  );
+
+  t.after(async () => {
+    await rm(testDirectory, { recursive: true, force: true, maxRetries: 3 });
+  });
+
+  return testDirectory;
+}
+
+function runDetachedFailureWorker(testDirectory) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WORKER_PATH, testDirectory], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let spawnError;
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, CHILD_PROCESS_TIMEOUT_MS);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', (error) => {
+      spawnError = error;
+    });
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(timeout);
+
+      if (timedOut) {
+        reject(new Error('detached-failure worker timed out'));
+        return;
+      }
+
+      if (spawnError) {
+        reject(
+          new Error(
+            `detached-failure worker failed to start: ${spawnError.name}`,
+          ),
+        );
+        return;
+      }
+
+      if (stderr.trim() !== '') {
+        reject(new Error('detached-failure worker wrote unexpected stderr'));
+        return;
+      }
+
+      let payload;
+      try {
+        payload = JSON.parse(stdout.trim());
+      } catch {
+        reject(new Error('detached-failure worker emitted invalid JSON'));
+        return;
+      }
+
+      if (exitCode !== 0 || signal !== null) {
+        reject(
+          new Error(
+            `detached-failure worker exited unexpectedly: ${payload.status}`,
+          ),
+        );
+        return;
+      }
+
+      resolve(payload);
+    });
+  });
+}
+
+test(
+  'awaiting _loadFromDir resolves before a gated descendant load completes',
+  { timeout: 15_000 },
+  async (t) => {
+    const testDirectory = await createTestDirectory(t);
+    const databaseDirectory = path.join(testDirectory, 'database');
+    const databasePath = `${databaseDirectory}${path.sep}`;
+    const seeded = new Moxley(databasePath);
+    seeded.db._create('descendant');
+
+    const reopened = new Moxley(databasePath);
+    const root = reopened.db;
+    const rootLocation = path.resolve(root._loc);
+    const descendantRequested = createDeferred();
+    const descendantGate = createDeferred();
+    const descendantCompleted = createDeferred();
+    const databasePrototype = Object.getPrototypeOf(root);
+    const originalPrototypeLoadFromDir = databasePrototype._loadFromDir;
+    const originalRootLoadState = root._loadState.bind(root);
+    const loadRoot = root._loadFromDir.bind(root);
+
+    root._loadState = async (location) => {
+      if (path.resolve(location) !== rootLocation) {
+        descendantRequested.resolve();
+        await descendantGate.promise;
+      }
+
+      return originalRootLoadState(location);
+    };
+
+    databasePrototype._loadFromDir = async function (...args) {
+      const result = await originalPrototypeLoadFromDir.apply(this, args);
+      if (this !== root) {
+        descendantCompleted.resolve();
+      }
+      return result;
+    };
+
+    let outerStatus = 'pending';
+    const outerSettlement = loadRoot().then(
+      (value) => {
+        outerStatus = 'resolved';
+        return { status: outerStatus, returnedSameRoot: value === root };
+      },
+      (error) => {
+        outerStatus = 'rejected';
+        return { status: outerStatus, errorName: error.name };
+      },
+    );
+
+    try {
+      await withTimeout(
+        descendantRequested.promise,
+        'descendant load request',
+      );
+      await new Promise((resolve) => setImmediate(resolve));
+
+      assert.equal(outerStatus, 'resolved');
+      assert.equal(descendantCompleted.settled, false);
+      assert.equal(root._children.length, 0);
+      assert.equal(root.descendant, null);
+    } finally {
+      descendantGate.resolve();
+      try {
+        await withTimeout(
+          descendantCompleted.promise,
+          'descendant load completion',
+        );
+      } finally {
+        databasePrototype._loadFromDir = originalPrototypeLoadFromDir;
+        delete root._loadState;
+      }
+    }
+
+    const outerResult = await withTimeout(outerSettlement, 'outer load');
+    assert.deepEqual(outerResult, {
+      status: 'resolved',
+      returnedSameRoot: true,
+    });
+    assert.equal(root._children.length, 1);
+    assert.equal(root.descendant === root._children[0], true);
+  },
+);
+
+test(
+  'descendant load failure is detached from the returned _loadFromDir promise',
+  { timeout: 15_000 },
+  async (t) => {
+    const testDirectory = await createTestDirectory(t);
+    const result = await runDetachedFailureWorker(testDirectory);
+
+    assert.deepEqual(result, {
+      status: 'characterized',
+      outerStatus: 'resolved',
+      returnedSameRoot: true,
+      outerResolvedBeforeDetachedRejection: true,
+      detachedRejections: [{ name: 'SyntaxError' }],
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Base commit: `532a5fca75ca2bf4e439eaac8a49d74b04fee6c7`

Head commit: `8b889129114121c455f60593e3ae2fb9518722b7`

This test/tooling-only PR adds deterministic upstream characterization for two current recursive load-readiness defects:

- awaiting `_loadFromDir()` resolves before a gated descendant load completes;
- a descendant load rejection is detached from the returned `_loadFromDir()` promise.

These passing tests are negative evidence; they do not establish that the behavior is acceptable.

## Deterministic synchronization

The readiness case gates the descendant state load with an explicit promise, observes the outer promise after an event-loop barrier while the gate remains closed, and then releases the gate and waits for an instrumented descendant-completion signal. It does not use elapsed-time ordering or polling.

The detached-rejection case runs entirely in a dedicated bounded worker. The worker separately records outer-promise resolution and the descendant `unhandledRejection`, and reports explicit timeout, outer-rejection, or unexpected-failure outcomes. All databases use separator-terminated paths in disposable operating-system temporary directories and are removed by test teardown.

## Verification

- `npm test` passed twice from the final source: 2/2 tests on each run (4/4 repeated test executions), with zero failures, skips, todos, or cancellations.
- `node --check` passed for all 4 repository JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed as JSON.
- `git diff --check` and `git diff --cached --check` passed.
- No repository-local database, persisted Moxley state, report, or generated test artifact appeared.
- The staged and committed path set is exactly `package.json`, `test/load-readiness.test.cjs`, and `test/fixtures/detached-load-failure-worker.cjs`.

## Scope boundary

Production source and runtime behavior are unchanged. The package version, dependencies, dependency versions, and `package-lock.json` are unchanged.

This PR does not repair or qualify lifecycle behavior. Any later readiness/error-propagation repair must be separately planned, reviewed, and tested.