### PR TITLE
Await recursive directory loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ class DB { // DataBase (root node)
                     this._template = this._parent._childTemplate
                 }
             }
-            fs.readdirSync(loc).forEach(async (entry) => {
+            for (const entry of fs.readdirSync(loc)) {
                 var dot = entry.indexOf('.')
                 if (dot == -1) {
                     var next = this._loc + '/' + entry + '/'
@@ -283,7 +283,7 @@ class DB { // DataBase (root node)
                         this[entry] = new Tupac(this, entry).dc
                     }
                 } 
-            })
+            }
         }
         return this
     }

--- a/test/fixtures/detached-load-failure-worker.cjs
+++ b/test/fixtures/detached-load-failure-worker.cjs
@@ -5,7 +5,7 @@ const path = require('node:path');
 
 const Moxley = require('../..');
 
-const DETACHED_REJECTION_TIMEOUT_MS = 5_000;
+const OUTER_SETTLEMENT_TIMEOUT_MS = 5_000;
 
 function errorName(error) {
   if (error && typeof error.name === 'string') {
@@ -18,23 +18,31 @@ function emit(payload) {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
 
-function waitForDetachedRejection(promise) {
+function observeOuterSettlement(promise) {
   return new Promise((resolve) => {
     const timeout = setTimeout(() => {
-      resolve(false);
-    }, DETACHED_REJECTION_TIMEOUT_MS);
+      resolve({ status: 'timeout' });
+    }, OUTER_SETTLEMENT_TIMEOUT_MS);
 
-    promise.then(() => {
-      clearTimeout(timeout);
-      resolve(true);
-    });
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve({ status: 'resolved', value });
+      },
+      (error) => {
+        clearTimeout(timeout);
+        resolve({ status: 'rejected', error });
+      },
+    );
   });
 }
 
 async function main() {
   const testDirectory = process.argv[2];
   if (!testDirectory || !path.isAbsolute(testDirectory)) {
-    throw new TypeError('worker requires an absolute test directory');
+    emit({ status: 'invalid-input' });
+    process.exitCode = 2;
+    return;
   }
 
   const databaseDirectory = path.join(testDirectory, 'database');
@@ -49,65 +57,67 @@ async function main() {
   const reopened = new Moxley(databasePath);
   const root = reopened.db;
   let outerStatus = 'pending';
-  let outerResolvedBeforeDetachedRejection = false;
   const detachedRejections = [];
-  let resolveDetachedRejection;
-  const detachedRejection = new Promise((resolve) => {
-    resolveDetachedRejection = resolve;
-  });
   const onUnhandledRejection = (error) => {
-    outerResolvedBeforeDetachedRejection = outerStatus === 'resolved';
     detachedRejections.push({ name: errorName(error) });
-    resolveDetachedRejection();
   };
 
   process.on('unhandledRejection', onUnhandledRejection);
 
   try {
-    const outerResult = await root._loadFromDir().then(
-      (value) => {
-        outerStatus = 'resolved';
-        return {
-          status: outerStatus,
-          returnedSameRoot: value === root,
-        };
-      },
-      (error) => {
-        outerStatus = 'rejected';
-        return {
-          status: outerStatus,
-          errorName: errorName(error),
-        };
-      },
-    );
+    const outerResult = await observeOuterSettlement(root._loadFromDir());
+    outerStatus = outerResult.status;
 
-    if (outerResult.status !== 'resolved') {
-      emit({
-        status: 'outer-rejected',
-        outerStatus,
-        errorName: outerResult.errorName,
-      });
-      process.exitCode = 2;
-      return;
-    }
-
-    const observed = await waitForDetachedRejection(detachedRejection);
-    if (!observed) {
+    if (outerStatus === 'timeout') {
       emit({
         status: 'timeout',
         outerStatus,
-        returnedSameRoot: outerResult.returnedSameRoot,
+        detachedRejections,
       });
       process.exitCode = 3;
       return;
     }
 
     await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    if (detachedRejections.length > 0) {
+      emit({
+        status: 'detached-rejection',
+        outerStatus,
+        detachedRejections,
+      });
+      process.exitCode = 4;
+      return;
+    }
+
+    if (outerStatus === 'resolved') {
+      emit({
+        status: 'unexpected-outer-resolution',
+        outerStatus,
+        returnedSameRoot: outerResult.value === root,
+        detachedRejections,
+      });
+      process.exitCode = 5;
+      return;
+    }
+
+    const outerErrorName = errorName(outerResult.error);
+    if (outerErrorName !== 'SyntaxError') {
+      emit({
+        status: 'unexpected-outer-rejection',
+        outerStatus,
+        outerErrorName,
+        detachedRejections,
+      });
+      process.exitCode = 6;
+      return;
+    }
+
     emit({
-      status: 'characterized',
+      status: 'propagated',
       outerStatus,
-      returnedSameRoot: outerResult.returnedSameRoot,
-      outerResolvedBeforeDetachedRejection,
+      outerErrorName,
       detachedRejections,
     });
   } finally {

--- a/test/load-readiness.test.cjs
+++ b/test/load-readiness.test.cjs
@@ -148,7 +148,7 @@ function runDetachedFailureWorker(testDirectory) {
 }
 
 test(
-  'awaiting _loadFromDir resolves before a gated descendant load completes',
+  'awaiting _loadFromDir establishes complete recursive readiness',
   { timeout: 15_000 },
   async (t) => {
     const testDirectory = await createTestDirectory(t);
@@ -204,7 +204,8 @@ test(
       );
       await new Promise((resolve) => setImmediate(resolve));
 
-      assert.equal(outerStatus, 'resolved');
+      assert.equal(descendantGate.settled, false);
+      assert.equal(outerStatus, 'pending');
       assert.equal(descendantCompleted.settled, false);
       assert.equal(root._children.length, 0);
       assert.equal(root.descendant, null);
@@ -221,6 +222,7 @@ test(
       }
     }
 
+    assert.equal(descendantGate.settled, true);
     const outerResult = await withTimeout(outerSettlement, 'outer load');
     assert.deepEqual(outerResult, {
       status: 'resolved',
@@ -232,18 +234,17 @@ test(
 );
 
 test(
-  'descendant load failure is detached from the returned _loadFromDir promise',
+  'descendant load failure rejects the returned _loadFromDir promise',
   { timeout: 15_000 },
   async (t) => {
     const testDirectory = await createTestDirectory(t);
     const result = await runDetachedFailureWorker(testDirectory);
 
     assert.deepEqual(result, {
-      status: 'characterized',
-      outerStatus: 'resolved',
-      returnedSameRoot: true,
-      outerResolvedBeforeDetachedRejection: true,
-      detachedRejections: [{ name: 'SyntaxError' }],
+      status: 'propagated',
+      outerStatus: 'rejected',
+      outerErrorName: 'SyntaxError',
+      detachedRejections: [],
     });
   },
 );


### PR DESCRIPTION
## Scope

Base commit: `ab59d3357568d878da1153be56793b0a6d454877`

Head commit: `83c52ce7b6745254320d515ac8cdcebdb759e642`

This branch starts directly from the squash-merge commit for characterization PR #4: [`ab59d3357568d878da1153be56793b0a6d454877`](https://github.com/dabbodev/Moxley/commit/ab59d3357568d878da1153be56793b0a6d454877).

Exact changed paths:

- `index.js`
- `test/load-readiness.test.cjs`
- `test/fixtures/detached-load-failure-worker.cjs`

## Prior observed defects

The merged characterization baseline deterministically demonstrated two lifecycle defects:

- awaiting `_loadFromDir()` resolved before a gated descendant load completed;
- a malformed descendant state rejection was detached from the returned outer promise and surfaced later as an `unhandledRejection`.

The negative characterization baseline passed 2/2 immediately before this repair branch was edited.

## Behavioral repair

Within `DB._loadFromDir()`, the detached `fs.readdirSync(loc).forEach(async (entry) => { ... })` traversal is replaced with direct sequential `for...of` iteration over the existing `fs.readdirSync(loc)` result.

The existing entry acceptance rule, path calculation, child and collection construction, persisted-state reads, and recursive call remain intact. Each accepted child recursion is now awaited before traversal continues. Successful completion still returns the same database node, but only after all accepted descendants finish. An original descendant error now rejects the returned outer promise unchanged rather than becoming detached.

Traversal is not sorted, reversed, filtered, parallelized, or passed through `Promise.all`. The order returned by `fs.readdirSync` is preserved. Persisted bytes, serialization, directory naming, and identity allocation are unchanged.

## Regression strategy

The readiness test retains disposable operating-system temporary directories, explicit deferred synchronization, and bounded waits. It proves a descendant request is gated, the outer promise remains pending and the descendant remains incomplete while the gate is closed, release permits recursive completion, the outer promise resolves to the same root object, and the descendant is available at await completion. No elapsed-time ordering or unbounded polling is used.

The failure scenario remains in a dedicated bounded worker. It corrupts descendant state, observes the outer promise and `unhandledRejection` independently, waits deterministic event-loop barriers for late detached work, and succeeds only with:

```json
{
  "status": "propagated",
  "outerStatus": "rejected",
  "outerErrorName": "SyntaxError",
  "detachedRejections": []
}
```

Timeout, invalid input, unexpected outer resolution, detached rejection, unexpected rejection type, and another unexpected failure each produce a distinct non-success status and nonzero exit. Worker JSON contains no absolute temporary paths.

## Verification

- Merged PR #4 negative baseline: 2/2 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final positive run 1: 2/2 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final positive run 2: 2/2 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- `node --check` passed for all 4 tracked JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, Moxley state, report, coverage output, or generated test artifact appeared.
- The complete and staged changed-path sets both equal the exact three-file allowlist.
- All protected files, including both manifests, licensing files, README, legacy test, and repository attributes, retain their base Git blobs.
- `git diff --check` and `git diff --cached --check` passed, and both complete diffs were reviewed.

## Compatibility and versioning

This intentionally changes promise timing and error propagation for `_loadFromDir()`: callers awaiting it now wait for recursive readiness, and descendant failures now reject that awaited promise. Successful resolution continues returning the same root node. No public API name or package export changes.

The package version remains `3.1.1`. Versioning and any npm publication are deferred to a later release decision.

## Explicit non-goals and nonclaims

This PR does not change duplicate named-child behavior, repeated-load mutation, restart identity, directory-order identity, `_id` allocation, path containment, symlink behavior, locking, concurrency, atomicity, journaling, recovery, durability, acknowledgement semantics, serialization, persisted format, CSV behavior, templates, collections, proxies, evaluated functions, public API names, or package exports.

It does not claim that Moxley is production-safe, broadly hardened, or qualified for Thoth. It fixes only recursive load readiness and descendant error propagation.