### PR TITLE
Characterize repeated load mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible class based database system for complicated schemas",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/load-readiness.test.cjs"
+    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs"
   },
   "keywords": [
     "database",

--- a/test/repeated-load-mutation.test.cjs
+++ b/test/repeated-load-mutation.test.cjs
@@ -1,0 +1,122 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { mkdtemp, readdir, rm, stat } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const Moxley = require('..');
+
+const CLEANUP_TIMEOUT_MS = 5_000;
+const TEST_TIMEOUT_MS = 15_000;
+
+function withTimeout(promise, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function createRepeatedLoadScenario(t) {
+  const testDirectory = await mkdtemp(
+    path.join(os.tmpdir(), 'moxley-repeated-load-'),
+  );
+
+  t.after(async () => {
+    await withTimeout(
+      rm(testDirectory, { recursive: true, force: true, maxRetries: 3 }),
+      'temporary directory cleanup',
+      CLEANUP_TIMEOUT_MS,
+    );
+  });
+
+  const databaseDirectory = path.join(testDirectory, 'database');
+  const databasePath = `${databaseDirectory}${path.sep}`;
+  const seeded = new Moxley(databasePath);
+  seeded.db._create('descendant');
+
+  const reopened = new Moxley(databasePath);
+  return {
+    databaseDirectory,
+    root: reopened.db,
+  };
+}
+
+test(
+  'calling _loadFromDir twice appends another reconstructed child',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { root } = await createRepeatedLoadScenario(t);
+
+    const firstResult = await root._loadFromDir();
+    const firstSnapshot = [...root._children];
+    const firstChild = firstSnapshot[0];
+
+    assert.strictEqual(firstResult, root);
+    assert.equal(firstSnapshot.length, 1);
+    assert.equal(firstChild._id, '0/0');
+
+    const secondResult = await root._loadFromDir();
+    const secondSnapshot = [...root._children];
+    const appendedChild = secondSnapshot[1];
+
+    assert.strictEqual(secondResult, root);
+    assert.equal(secondSnapshot.length, 2);
+    assert.strictEqual(secondSnapshot[0], firstChild);
+    assert.notStrictEqual(appendedChild, firstChild);
+    assert.equal(firstChild._id, '0/0');
+    assert.equal(appendedChild._id, '0/1');
+  },
+);
+
+test(
+  'repeated _loadFromDir keeps named lookup on the first child while creating a new directory',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory, root } =
+      await createRepeatedLoadScenario(t);
+
+    await root._loadFromDir();
+    const firstChild = root._children[0];
+    const firstNamedLookup = root.descendant;
+    const firstEntries = (await readdir(databaseDirectory)).sort();
+    const secondDirectory = path.join(databaseDirectory, '1');
+
+    assert.strictEqual(firstNamedLookup, firstChild);
+    await assert.rejects(
+      stat(secondDirectory),
+      (error) => error && error.code === 'ENOENT',
+    );
+
+    await root._loadFromDir();
+    const appendedChild = root._children[1];
+    const secondEntries = (await readdir(databaseDirectory)).sort();
+    const firstEntrySet = new Set(firstEntries);
+    const secondEntrySet = new Set(secondEntries);
+    const removedEntries = firstEntries.filter(
+      (entry) => !secondEntrySet.has(entry),
+    );
+    const addedEntries = secondEntries.filter(
+      (entry) => !firstEntrySet.has(entry),
+    );
+
+    assert.equal((await stat(secondDirectory)).isDirectory(), true);
+    assert.deepEqual(removedEntries, []);
+    assert.deepEqual(addedEntries, ['1']);
+    assert.strictEqual(root.descendant, firstChild);
+    assert.notStrictEqual(root.descendant, appendedChild);
+  },
+);


### PR DESCRIPTION
## Scope

Base commit: `2f97d45f9ac78d8dcd82cb1370e098ca402287b2`

Head commit: `207e4bfe5ac48d9ed389242a89557ff1cb2213eb`

This branch starts directly from the authoritative PR #5 squash-merge commit: [`2f97d45f9ac78d8dcd82cb1370e098ca402287b2`](https://github.com/dabbodev/Moxley/commit/2f97d45f9ac78d8dcd82cb1370e098ca402287b2).

Exact changed paths:

- `package.json`
- `test/repeated-load-mutation.test.cjs`

The package test command now names the readiness and repeated-load characterization files explicitly. Production source and runtime behavior are unchanged.

## Observed repeated-load outcomes

When the same fresh reopened root awaits `_loadFromDir()` twice:

- the second call appends another reconstructed child, growing `_children` from one entry to two;
- the first reconstructed child retains in-memory `_id` `0/0`, while the appended child receives the new in-memory `_id` `0/1`;
- a new physical root child directory named `1` is created by the second load;
- the existing named lookup `root.descendant` continues resolving to the first reconstructed child, not the appended duplicate.

These are negative characterization facts, not approved behavior.

## Test isolation and cleanup

Each test creates its own unique directory beneath the operating-system temporary directory, appends `path.sep` to the database path, seeds exactly one named child (`descendant`), constructs a fresh reopened root, and awaits each load before taking its snapshot. Cleanup is registered immediately and is unconditional, recursively bounded by retry count and a 5-second timeout. The tests write no repository files. Filesystem entry comparisons use sorted test-only snapshots and set membership; they do not infer or impose production traversal order. No elapsed-time ordering or unbounded polling is used.

## Verification

- Merged PR #5 positive baseline before editing: 2/2 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 1: 4/4 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 2: 4/4 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- `node --check` passed for all five repository JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, Moxley state, coverage output, report, generated artifact, or leftover test temporary directory appeared.
- The complete and staged changed-path sets both equal the exact two-file allowlist.
- `index.js`, the existing readiness tests and worker, `package-lock.json`, `test.js`, README, licensing files, package version, and dependencies retain their PR #5 merge-base content.
- `git diff --check` and `git diff --cached --check` passed, and the complete working-tree and staged diffs were reviewed.

## Explicit non-goals and nonclaims

This PR does not repair or select semantics for repeated loading, duplicate `_create(name)` calls, restart load-check-create behavior, stable persisted identity, directory-order identity, path naming, binding replacement, deduplication, clearing existing children, locking or concurrency, atomicity, recovery or durability, or serialization or format versioning.

It does not claim that the new physical directory contains valid reconstructed data, that duplicate nodes are equivalent, or that Moxley is production-safe. It makes no package-version or persisted-format decision. Apart from disposable runtime state created by the tests beneath the OS temporary directory and removed during cleanup, this characterization slice does not change persisted bytes.