### PR TITLE
Make repeated directory loading idempotent

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+const path = require('path');
 const {parse, stringify} = require('flatted');
 
 class DB { // DataBase (root node)
@@ -276,9 +277,14 @@ class DB { // DataBase (root node)
                     var next = this._loc + '/' + entry + '/'
                     statecheck = next + '_state.ms'
                     if (fs.existsSync(statecheck)) {
-                        var childstate = await this._loadState(next)
-                        var i = this._children.push(new WillSmith({}, this, childstate._name).dn) - 1
-                        await this._children[i]._loadFromDir()
+                        var existingChild = this._children.find((child) => path.resolve(child._loc) === path.resolve(next))
+                        if (existingChild) {
+                            await existingChild._loadFromDir()
+                        } else {
+                            var childstate = await this._loadState(next)
+                            var i = this._children.push(new WillSmith({}, this, childstate._name).dn) - 1
+                            await this._children[i]._loadFromDir()
+                        }
                     } else {
                         this[entry] = new Tupac(this, entry).dc
                     }

--- a/test/repeated-load-mutation.test.cjs
+++ b/test/repeated-load-mutation.test.cjs
@@ -56,7 +56,7 @@ async function createRepeatedLoadScenario(t) {
 }
 
 test(
-  'calling _loadFromDir twice appends another reconstructed child',
+  'calling _loadFromDir twice preserves reconstructed child identity',
   { timeout: TEST_TIMEOUT_MS },
   async (t) => {
     const { root } = await createRepeatedLoadScenario(t);
@@ -71,19 +71,21 @@ test(
 
     const secondResult = await root._loadFromDir();
     const secondSnapshot = [...root._children];
-    const appendedChild = secondSnapshot[1];
+    const childAfterSecondLoad = secondSnapshot[0];
 
     assert.strictEqual(secondResult, root);
-    assert.equal(secondSnapshot.length, 2);
-    assert.strictEqual(secondSnapshot[0], firstChild);
-    assert.notStrictEqual(appendedChild, firstChild);
-    assert.equal(firstChild._id, '0/0');
-    assert.equal(appendedChild._id, '0/1');
+    assert.equal(secondSnapshot.length, 1);
+    assert.strictEqual(childAfterSecondLoad, firstChild);
+    assert.equal(childAfterSecondLoad._id, '0/0');
+    assert.equal(
+      secondSnapshot.some((child) => child._id === '0/1'),
+      false,
+    );
   },
 );
 
 test(
-  'repeated _loadFromDir keeps named lookup on the first child while creating a new directory',
+  'repeated _loadFromDir preserves named lookup and directory entries',
   { timeout: TEST_TIMEOUT_MS },
   async (t) => {
     const { databaseDirectory, root } =
@@ -102,21 +104,15 @@ test(
     );
 
     await root._loadFromDir();
-    const appendedChild = root._children[1];
     const secondEntries = (await readdir(databaseDirectory)).sort();
-    const firstEntrySet = new Set(firstEntries);
-    const secondEntrySet = new Set(secondEntries);
-    const removedEntries = firstEntries.filter(
-      (entry) => !secondEntrySet.has(entry),
-    );
-    const addedEntries = secondEntries.filter(
-      (entry) => !firstEntrySet.has(entry),
-    );
 
-    assert.equal((await stat(secondDirectory)).isDirectory(), true);
-    assert.deepEqual(removedEntries, []);
-    assert.deepEqual(addedEntries, ['1']);
+    assert.deepEqual(secondEntries, firstEntries);
+    await assert.rejects(
+      stat(secondDirectory),
+      (error) => error && error.code === 'ENOENT',
+    );
     assert.strictEqual(root.descendant, firstChild);
-    assert.notStrictEqual(root.descendant, appendedChild);
+    assert.strictEqual(root._children[0], firstChild);
+    assert.equal(root._children.length, 1);
   },
 );


### PR DESCRIPTION
## Scope

Base commit: `f714010225e0009ab7c61992993e9bb6129ae19a`

Head commit: `d7476bed43bf82d05dea6cc00ac00091c41a086a`

This branch starts directly from the authoritative PR #6 squash-merge commit: [`f714010225e0009ab7c61992993e9bb6129ae19a`](https://github.com/dabbodev/Moxley/commit/f714010225e0009ab7c61992993e9bb6129ae19a).

Exact changed paths:

- `index.js`
- `test/repeated-load-mutation.test.cjs`

## Prior negative observations

The merged characterization proved that awaiting `_loadFromDir()` twice on the same fresh reopened live root previously:

- appended another reconstructed child, growing `_children` from one entry to two;
- left the first child at in-memory `_id` `0/0` while assigning the duplicate `_id` `0/1`;
- created an unintended physical root child directory named `1`;
- kept `root.descendant` bound to the first reconstructed child rather than the appended duplicate.

## Repair mechanism

The production change is limited to the state-file-backed child branch inside `DB._loadFromDir()`. Before constructing a child for an existing physical child directory, it searches the existing `_children` for a child whose `_loc` resolves to the same platform-normalized physical location as the internally derived `next` directory. When a match exists, it directly awaits that existing child’s `_loadFromDir()` without pushing, constructing, renaming, rebinding, or reassigning it. When no match exists, the prior first-load reconstruction path remains unchanged.

The comparison uses `path.resolve` only to compare two internally derived physical locations. It does not establish a caller path, containment, canonical-path, symlink, display-name, cross-process, or public identity contract. Direct sequential traversal of the unsorted `fs.readdirSync(loc)` result, entry acceptance, state-file/collection distinction, recursive awaiting, and original error propagation remain intact.

## Regression results

The existing two characterization tests retain their unique OS-temporary directories, trailing path separators, single `descendant` seed, fresh reopened roots, bounded cleanup, and four-test aggregate count. They now prove that a second completed load:

- returns the same root;
- leaves exactly one child and preserves the exact child object;
- preserves `_id` `0/0` with no appended `0/1` child;
- preserves `root.descendant`, `_children[0]`, and the complete sorted root-directory entry array;
- does not create physical directory `1`.

Verification:

- Merged PR #6 negative baseline before editing: 4/4 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final repaired run 1: 4/4 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final repaired run 2: 4/4 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- `node --check` passed for all five JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, state, coverage output, report, generated artifact, or leftover test temporary directory appeared.
- The complete and staged changed-path sets both equal the exact two-file allowlist.
- All protected paths, package version, and dependencies retain their PR #6 merge-base content.
- `git diff --check` and `git diff --cached --check` passed, both complete diffs were reviewed, and the original `index.js` no-final-newline framing was preserved.

## Compatibility and persistence boundary

Awaited first-load readiness and descendant error propagation introduced by PR #5 remain unchanged. The intentional behavior change is limited to a second same-live-root load: it no longer appends a duplicate reconstructed child or creates unintended directory `1`, and it still recursively awaits the reused child before returning the same root.

Existing legitimate files are not rewritten. Serialization syntax and persisted-format interpretation are unchanged, and there is no migration. The repair intentionally prevents the defective second-load side effect’s extra bytes from being created; it does not claim byte-for-byte equivalence with that old side effect. Preventing this unintended artifact is not a general atomicity, recovery, or durability guarantee.

## Explicit non-goals and nonclaims

This PR does not change or select semantics for duplicate caller-driven `_create(name)`, restart load-check-create behavior, initial-load binding artifacts, directory-order identity, cross-process identity, `_id` format, path containment or symlinks, collections on repeated load beyond existing behavior, locking or concurrency, atomicity, journaling, recovery or durability, cancellation, format versioning, or package release versioning.

It does not claim that Moxley is production-safe or qualified for Thoth. Dependencies, package version, persisted format, public API names, and unrelated behavior are unchanged.