### PR TITLE
Characterize duplicate named creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible class based database system for complicated schemas",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs"
+    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs"
   },
   "keywords": [
     "database",

--- a/test/duplicate-create.test.cjs
+++ b/test/duplicate-create.test.cjs
@@ -1,0 +1,127 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { mkdtemp, readdir, readFile, rm, stat } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const Moxley = require('..');
+
+const CLEANUP_TIMEOUT_MS = 5_000;
+const TEST_TIMEOUT_MS = 15_000;
+
+function withTimeout(promise, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function createDuplicateCreateScenario(t) {
+  const testDirectory = await mkdtemp(
+    path.join(os.tmpdir(), 'moxley-duplicate-create-'),
+  );
+
+  t.after(async () => {
+    await withTimeout(
+      rm(testDirectory, { recursive: true, force: true, maxRetries: 3 }),
+      'temporary directory cleanup',
+      CLEANUP_TIMEOUT_MS,
+    );
+  });
+
+  const databaseDirectory = path.join(testDirectory, 'database');
+  const databasePath = `${databaseDirectory}${path.sep}`;
+  const database = new Moxley(databasePath);
+
+  return {
+    databaseDirectory,
+    root: database.db,
+  };
+}
+
+test(
+  'duplicate _create returns a distinct appended child while named lookup stays on the first',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { root } = await createDuplicateCreateScenario(t);
+
+    const first = root._create('descendant');
+    const second = root._create('descendant');
+
+    assert.equal(typeof first, 'object');
+    assert.notEqual(first, null);
+    assert.equal(typeof second, 'object');
+    assert.notEqual(second, null);
+    assert.notStrictEqual(second, first);
+    assert.equal(root._children.length, 2);
+    assert.strictEqual(root._children[0], first);
+    assert.strictEqual(root._children[1], second);
+    assert.equal(first._id, '0/0');
+    assert.equal(second._id, '0/1');
+    assert.equal(first._name, 'descendant');
+    assert.equal(second._name, 'descendant');
+    assert.strictEqual(root.descendant, first);
+    assert.notStrictEqual(root.descendant, second);
+  },
+);
+
+test(
+  'duplicate _create creates a second directory without changing the named link',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory, root } =
+      await createDuplicateCreateScenario(t);
+    const firstDirectory = path.join(databaseDirectory, '0');
+    const secondDirectory = path.join(databaseDirectory, '1');
+    const namedLinkPath = path.join(databaseDirectory, 'descendant.ml');
+    const rootStatePath = path.join(databaseDirectory, '_state.ms');
+
+    root._create('descendant');
+    const firstEntries = (await readdir(databaseDirectory)).sort();
+    const firstNamedLinkBytes = await readFile(namedLinkPath);
+    const firstRootStateBytes = await readFile(rootStatePath);
+
+    assert.deepEqual(firstEntries, ['0', '_state.ms', 'descendant.ml']);
+    assert.equal(path.basename(namedLinkPath), 'descendant.ml');
+    assert.equal(firstNamedLinkBytes.toString('utf8'), '0/0');
+
+    root._create('descendant');
+    const secondEntries = (await readdir(databaseDirectory)).sort();
+    const firstEntrySet = new Set(firstEntries);
+    const secondEntrySet = new Set(secondEntries);
+    const removedEntries = firstEntries.filter(
+      (entry) => !secondEntrySet.has(entry),
+    );
+    const addedEntries = secondEntries.filter(
+      (entry) => !firstEntrySet.has(entry),
+    );
+    const secondNamedLinkBytes = await readFile(namedLinkPath);
+    const secondRootStateBytes = await readFile(rootStatePath);
+
+    assert.deepEqual(removedEntries, []);
+    assert.deepEqual(addedEntries, ['1']);
+    assert.equal((await stat(firstDirectory)).isDirectory(), true);
+    assert.equal((await stat(secondDirectory)).isDirectory(), true);
+    assert.equal(
+      (await stat(path.join(secondDirectory, '_state.ms'))).isFile(),
+      true,
+    );
+    assert.deepEqual(secondNamedLinkBytes, firstNamedLinkBytes);
+    assert.equal(secondNamedLinkBytes.toString('utf8'), '0/0');
+    assert.deepEqual(secondRootStateBytes, firstRootStateBytes);
+  },
+);


### PR DESCRIPTION
## Scope

Base commit: `389d52ce3d7986e66f82e5ef5de4b4e36f4f5f7d`

Head commit: `b69eabd04d5bccdb5620a1a5a2117e302d4d41f5`

This branch starts directly from the authoritative PR #7 squash-merge commit: [`389d52ce3d7986e66f82e5ef5de4b4e36f4f5f7d`](https://github.com/dabbodev/Moxley/commit/389d52ce3d7986e66f82e5ef5de4b4e36f4f5f7d).

Exact changed paths:

- `package.json`
- `test/duplicate-create.test.cjs`

The package test command now names all three test files explicitly. This PR changes no production source or runtime behavior.

## Observed duplicate named creation behavior

Two consecutive caller-driven calls to `root._create('descendant')` currently produce these negative characterization facts:

- both calls return object values, and the returned objects are distinct;
- `_children` contains two entries: index `0` is exactly the first return value and index `1` is exactly the second;
- the first child has `_id` `0/0`, the second has `_id` `0/1`, and both have in-memory `_name` `descendant`;
- `root.descendant` continues resolving to the first child and does not resolve to the second;
- after the first call, sorted root entries are exactly `0`, `_state.ms`, and `descendant.ml`;
- `descendant.ml` contains exactly `0/0`;
- after the second call, directory `1` is the only added root entry and no root entry is removed;
- directories `0` and `1` both exist, and `1/_state.ms` is a regular file;
- `descendant.ml` remains byte-identical to its first-call snapshot and still contains exactly `0/0`;
- root `_state.ms` content remains byte-identical to its first-call snapshot.

No modification-time evidence is used, so content equality is not presented as proof that a byte-identical file was not rewritten. These observations do not approve duplicate creation as intended behavior.

## Test isolation and cleanup

Each test creates a unique directory beneath the operating-system temporary directory, appends `path.sep` to its database path, registers unconditional cleanup bounded by retry count and a 5-second timeout, constructs a fresh database root, and invokes `_create('descendant')` exactly twice. Tests write no repository files, use bounded test-runner timeouts, and contain no elapsed-time assertions or polling. Disposable files are removed during cleanup.

## Verification

- Merged PR #7 positive baseline before editing: 4/4 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 1: 6/6 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 2: 6/6 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- `node --check` passed for all six JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, state, coverage output, report, generated artifact, or leftover Moxley test directory appeared.
- The complete and staged changed-path sets both equal the exact two-file allowlist.
- Production source, existing tests and worker, lockfile, README, licensing files, package version, and dependencies retain their PR #7 merge-base content.
- `git diff --check` and `git diff --cached --check` passed, and the complete working-tree and staged diffs were reviewed.

## Compatibility boundary

This PR is test-only. It makes no production behavior, persisted-format, migration, dependency, version, or release change. The recursive-load readiness and error-propagation guarantees from PR #5 and same-live-root repeated-load behavior from PR #7 are unchanged.

## Explicit non-goals and nonclaims

This PR does not select or implement whether duplicate named creation should return the existing child, reject, replace the named binding, create a distinct unnamed child, preserve the current duplicate behavior, or use a separate ensure/get-or-create API.

It also defers duplicate unnamed `_create`, `_store`, restart load-check-create behavior, repeated-load behavior already resolved by PR #7, directory-order identity, persisted stable identity, name validation or normalization, paths and symlinks, concurrency or locking, atomicity, recovery or durability, and format or package versioning.

It does not claim the second child is equivalent to the first, reachable by name, safe to persist, or intended API behavior. It does not claim Moxley is production-safe or qualified for Thoth. No duplicate-name policy, dependency, package version, persisted format, migration, or release was selected.