### PR TITLE
Characterize restart load-create identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible class based database system for complicated schemas",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs"
+    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs test/restart-load-create.test.cjs"
   },
   "keywords": [
     "database",

--- a/test/fixtures/restart-load-create-worker.cjs
+++ b/test/fixtures/restart-load-create-worker.cjs
@@ -1,0 +1,114 @@
+'use strict';
+
+const path = require('node:path');
+
+const Moxley = require('../..');
+
+const SUPPORTED_OPERATIONS = new Set(['load-create', 'inspect']);
+
+function errorName(error) {
+  if (error && typeof error.name === 'string') {
+    return error.name;
+  }
+  return typeof error;
+}
+
+function emit(payload) {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+function invalidInput(status) {
+  emit({ status });
+  process.exitCode = 2;
+}
+
+async function loadCreate(databasePath) {
+  const database = new Moxley(databasePath);
+  const root = database.db;
+  const loadResult = await root._loadFromDir();
+  const beforeChildren = [...root._children];
+  const reconstructedChild = beforeChildren[0];
+  const beforeNamedChild = root.descendant;
+  const createdChild = root._create('descendant');
+  const afterChildren = [...root._children];
+  const afterNamedChild = root.descendant;
+
+  emit({
+    status: 'load-create-observed',
+    loadReturnedSameRoot: loadResult === root,
+    beforeChildCount: beforeChildren.length,
+    beforeChildIds: beforeChildren.map((child) => child._id),
+    beforeChildNames: beforeChildren.map((child) => child._name),
+    beforeNamedChildIndex: beforeChildren.indexOf(beforeNamedChild),
+    beforeNamedIsReconstructed: beforeNamedChild === reconstructedChild,
+    createdReturnedObject:
+      createdChild !== null && typeof createdChild === 'object',
+    createdDistinctFromReconstructed: createdChild !== reconstructedChild,
+    createdId: createdChild._id,
+    createdName: createdChild._name,
+    afterChildCount: afterChildren.length,
+    afterChildIds: afterChildren.map((child) => child._id),
+    afterChildNames: afterChildren.map((child) => child._name),
+    afterFirstIsReconstructed: afterChildren[0] === reconstructedChild,
+    afterSecondIsCreated: afterChildren[1] === createdChild,
+    afterNamedChildIndex: afterChildren.indexOf(afterNamedChild),
+    afterNamedIsReconstructed: afterNamedChild === reconstructedChild,
+    afterNamedIsCreated: afterNamedChild === createdChild,
+  });
+}
+
+async function inspect(databasePath) {
+  const database = new Moxley(databasePath);
+  const root = database.db;
+  const loadResult = await root._loadFromDir();
+  const children = [...root._children];
+  const namedChild = root.descendant;
+
+  emit({
+    status: 'inspect-observed',
+    loadReturnedSameRoot: loadResult === root,
+    childCount: children.length,
+    childIds: children.map((child) => child._id),
+    childNames: children.map((child) => child._name),
+    namedChildIndex: children.indexOf(namedChild),
+    namedIsFirst: namedChild === children[0],
+    namedIsSecond: namedChild === children[1],
+  });
+}
+
+async function main() {
+  if (process.argv.length !== 4) {
+    invalidInput('invalid-arguments');
+    return;
+  }
+
+  const operation = process.argv[2];
+  const databaseDirectory = process.argv[3];
+
+  if (!SUPPORTED_OPERATIONS.has(operation)) {
+    invalidInput('unsupported-operation');
+    return;
+  }
+
+  if (!path.isAbsolute(databaseDirectory)) {
+    invalidInput('invalid-database-directory');
+    return;
+  }
+
+  const databasePath = `${databaseDirectory}${path.sep}`;
+
+  if (operation === 'load-create') {
+    await loadCreate(databasePath);
+    return;
+  }
+
+  await inspect(databasePath);
+}
+
+main().catch((error) => {
+  emit({
+    status: 'unexpected-failure',
+    errorName: errorName(error),
+  });
+  process.exitCode = 1;
+});

--- a/test/restart-load-create.test.cjs
+++ b/test/restart-load-create.test.cjs
@@ -1,0 +1,335 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const { mkdtemp, readdir, readFile, rm, stat } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+const { parse } = require('flatted');
+
+const Moxley = require('..');
+
+const WORKER_PATH = path.join(
+  __dirname,
+  'fixtures',
+  'restart-load-create-worker.cjs',
+);
+const CHILD_PROCESS_TIMEOUT_MS = 10_000;
+const CLEANUP_TIMEOUT_MS = 5_000;
+const TEST_TIMEOUT_MS = 35_000;
+
+const EXPECTED_LOAD_CREATE = {
+  status: 'load-create-observed',
+  loadReturnedSameRoot: true,
+  beforeChildCount: 1,
+  beforeChildIds: ['0/0'],
+  beforeChildNames: ['root'],
+  beforeNamedChildIndex: 0,
+  beforeNamedIsReconstructed: true,
+  createdReturnedObject: true,
+  createdDistinctFromReconstructed: true,
+  createdId: '0/1',
+  createdName: 'descendant',
+  afterChildCount: 2,
+  afterChildIds: ['0/0', '0/1'],
+  afterChildNames: ['root', 'descendant'],
+  afterFirstIsReconstructed: true,
+  afterSecondIsCreated: true,
+  afterNamedChildIndex: 0,
+  afterNamedIsReconstructed: true,
+  afterNamedIsCreated: false,
+};
+
+const EXPECTED_INSPECT = {
+  status: 'inspect-observed',
+  loadReturnedSameRoot: true,
+  childCount: 2,
+  childIds: ['0/0', '0/1'],
+  childNames: ['root', 'root'],
+  namedChildIndex: 0,
+  namedIsFirst: true,
+  namedIsSecond: false,
+};
+
+function withTimeout(promise, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function createRestartScenario(t) {
+  const testDirectory = await mkdtemp(
+    path.join(os.tmpdir(), 'moxley-restart-load-create-'),
+  );
+
+  t.after(async () => {
+    await withTimeout(
+      rm(testDirectory, { recursive: true, force: true, maxRetries: 3 }),
+      'temporary directory cleanup',
+      CLEANUP_TIMEOUT_MS,
+    );
+  });
+
+  const databaseDirectory = path.join(testDirectory, 'database');
+  const databasePath = `${databaseDirectory}${path.sep}`;
+  const database = new Moxley(databasePath);
+  const root = database.db;
+  const seededChild = root._create('descendant');
+
+  return {
+    databaseDirectory,
+    root,
+    seededChild,
+  };
+}
+
+function runWorker(operation, databaseDirectory) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [WORKER_PATH, operation, databaseDirectory],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      },
+    );
+    let stdout = '';
+    let stderr = '';
+    let spawnError;
+    let settled = false;
+
+    function fail(message) {
+      if (!settled) {
+        settled = true;
+        reject(new Error(message));
+      }
+    }
+
+    const timeout = setTimeout(() => {
+      child.kill();
+      fail(`${operation} worker timed out`);
+    }, CHILD_PROCESS_TIMEOUT_MS);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', (error) => {
+      spawnError = error;
+    });
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(timeout);
+
+      if (settled) {
+        return;
+      }
+
+      if (spawnError) {
+        fail(`${operation} worker failed to start: ${spawnError.name}`);
+        return;
+      }
+
+      if (signal !== null) {
+        fail(`${operation} worker exited by signal`);
+        return;
+      }
+
+      if (stderr !== '') {
+        fail(`${operation} worker wrote unexpected stderr`);
+        return;
+      }
+
+      if (
+        !stdout.endsWith('\n') ||
+        stdout.slice(0, -1).includes('\n') ||
+        stdout.slice(0, -1).endsWith('\r')
+      ) {
+        fail(`${operation} worker emitted invalid framing`);
+        return;
+      }
+
+      let payload;
+      try {
+        payload = JSON.parse(stdout.slice(0, -1));
+      } catch {
+        fail(`${operation} worker emitted invalid JSON`);
+        return;
+      }
+
+      if (exitCode !== 0) {
+        const status =
+          payload && typeof payload.status === 'string'
+            ? payload.status
+            : 'unknown';
+        fail(`${operation} worker exited unexpectedly: ${status}`);
+        return;
+      }
+
+      const expectedStatus =
+        operation === 'load-create'
+          ? 'load-create-observed'
+          : 'inspect-observed';
+      if (!payload || payload.status !== expectedStatus) {
+        fail(`${operation} worker emitted unexpected status`);
+        return;
+      }
+
+      settled = true;
+      resolve(payload);
+    });
+  });
+}
+
+async function directoryEntries(databaseDirectory, entries) {
+  const directories = [];
+
+  for (const entry of entries) {
+    if ((await stat(path.join(databaseDirectory, entry))).isDirectory()) {
+      directories.push(entry);
+    }
+  }
+
+  return directories;
+}
+
+test(
+  'fresh-process load then duplicate _create appends a child while named lookup stays reconstructed first',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory, root, seededChild } =
+      await createRestartScenario(t);
+    const namedLinkPath = path.join(databaseDirectory, 'descendant.ml');
+    const rootStatePath = path.join(databaseDirectory, '_state.ms');
+    const initialEntries = (await readdir(databaseDirectory)).sort();
+    const initialDirectories = await directoryEntries(
+      databaseDirectory,
+      initialEntries,
+    );
+    const initialNamedLinkBytes = await readFile(namedLinkPath);
+    const initialRootStateBytes = await readFile(rootStatePath);
+    const initialRootState = parse(initialRootStateBytes.toString('utf8'));
+
+    assert.equal(seededChild._id, '0/0');
+    assert.strictEqual(root._children[0], seededChild);
+    assert.equal(root._children.length, 1);
+    assert.deepEqual(initialEntries, [
+      '0',
+      '_state.ms',
+      'descendant.ml',
+    ]);
+    assert.deepEqual(initialDirectories, ['0']);
+    assert.equal(initialNamedLinkBytes.toString('utf8'), '0/0');
+    assert.deepEqual(initialRootState._keys, ['descendant']);
+
+    const loadCreateResult = await runWorker(
+      'load-create',
+      databaseDirectory,
+    );
+    assert.deepEqual(loadCreateResult, EXPECTED_LOAD_CREATE);
+
+    const finalEntries = (await readdir(databaseDirectory)).sort();
+    const finalDirectories = await directoryEntries(
+      databaseDirectory,
+      finalEntries,
+    );
+    const addedDirectories = finalDirectories.filter(
+      (entry) => !initialDirectories.includes(entry),
+    );
+    const finalNamedLinkBytes = await readFile(namedLinkPath);
+    const finalRootStateBytes = await readFile(rootStatePath);
+    const finalRootState = parse(finalRootStateBytes.toString('utf8'));
+
+    assert.deepEqual(finalEntries, [
+      '0',
+      '1',
+      '_state.ms',
+      'descendant.ml',
+      'root.ml',
+    ]);
+    assert.deepEqual(addedDirectories, ['1']);
+    assert.equal(
+      (await stat(path.join(databaseDirectory, '0'))).isDirectory(),
+      true,
+    );
+    assert.equal(
+      (await stat(path.join(databaseDirectory, '1'))).isDirectory(),
+      true,
+    );
+    assert.equal(
+      (
+        await stat(
+          path.join(databaseDirectory, '1', '_state.ms'),
+        )
+      ).isFile(),
+      true,
+    );
+    assert.deepEqual(finalNamedLinkBytes, initialNamedLinkBytes);
+    assert.equal(finalNamedLinkBytes.toString('utf8'), '0/0');
+    assert.notDeepEqual(finalRootStateBytes, initialRootStateBytes);
+    assert.deepEqual(finalRootState._keys, ['descendant', 'root']);
+  },
+);
+
+test(
+  'a second fresh-process load reconstructs both children while the original named link remains',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory } = await createRestartScenario(t);
+    const namedLinkPath = path.join(databaseDirectory, 'descendant.ml');
+    const rootStatePath = path.join(databaseDirectory, '_state.ms');
+
+    const loadCreateResult = await runWorker(
+      'load-create',
+      databaseDirectory,
+    );
+    assert.deepEqual(loadCreateResult, EXPECTED_LOAD_CREATE);
+
+    const beforeInspectEntries = (
+      await readdir(databaseDirectory)
+    ).sort();
+    const beforeInspectNamedLinkBytes = await readFile(namedLinkPath);
+    const beforeInspectRootStateBytes = await readFile(rootStatePath);
+
+    const inspectResult = await runWorker('inspect', databaseDirectory);
+    assert.deepEqual(inspectResult, EXPECTED_INSPECT);
+
+    const afterInspectEntries = (
+      await readdir(databaseDirectory)
+    ).sort();
+    const afterInspectNamedLinkBytes = await readFile(namedLinkPath);
+    const afterInspectRootStateBytes = await readFile(rootStatePath);
+
+    assert.deepEqual(afterInspectEntries, beforeInspectEntries);
+    await assert.rejects(
+      stat(path.join(databaseDirectory, '2')),
+      (error) => error && error.code === 'ENOENT',
+    );
+    assert.deepEqual(
+      afterInspectNamedLinkBytes,
+      beforeInspectNamedLinkBytes,
+    );
+    assert.equal(afterInspectNamedLinkBytes.toString('utf8'), '0/0');
+    assert.deepEqual(
+      afterInspectRootStateBytes,
+      beforeInspectRootStateBytes,
+    );
+  },
+);


### PR DESCRIPTION
## Scope

Base commit: `2f350d7745cb3107a2232d6a82dbbe1a5e0d8143`

Head commit: `837b27b69ccf5b0c91780c1f8bff77d1c39fdf2d`

This branch starts directly from the authoritative PR #8 squash-merge commit: [`2f350d7745cb3107a2232d6a82dbbe1a5e0d8143`](https://github.com/dabbodev/Moxley/commit/2f350d7745cb3107a2232d6a82dbbe1a5e0d8143).

Exact changed paths:

- `package.json`
- `test/restart-load-create.test.cjs`
- `test/fixtures/restart-load-create-worker.cjs`

The package test command now names all four test files explicitly. Production source and runtime behavior are unchanged.

## Why fresh processes are required

The subject is restart load-check-create identity, so process-local object references cannot supply the evidence. The parent seeds one child, a fresh `load-create` worker reconstructs and then creates, and a separate fresh `inspect` worker reconstructs the resulting physical state. This separates same-process creation observations from persisted/reconstructed observations without assigning either a future semantic policy.

## Worker operations and bounds

The CommonJS worker accepts exactly `node restart-load-create-worker.cjs <operation> <absolute-database-directory>` and appends `path.sep` internally. Supported operations are `load-create` and `inspect`. Missing, extra, unsupported, and non-absolute input produce one deterministic JSON object plus LF and exit `2`; unexpected failures preserve only the thrown error name and exit `1`. Expected output contains no absolute temporary path or stack.

The parent uses `child_process.spawn` without a shell. Every child has a 10-second timeout and is killed on timeout; every test has a 35-second runner timeout. Timeout, signal, stderr, invalid framing, invalid JSON, nonzero exit, and unexpected status each fail with deterministic path-free text. Cleanup is unconditional, recursively bounded by retry count and a 5-second timeout.

## Exact observations

`load-create` in a fresh process observes:

- the awaited load returns the same root;
- before creation there is one reconstructed child with `_id` `0/0` and in-memory name `root`;
- `root.descendant` resolves to that reconstructed child;
- `_create('descendant')` returns a distinct object with `_id` `0/1` and name `descendant`;
- `_children` becomes exactly those two objects in order, with IDs `0/0` and `0/1` and names `root` and `descendant`;
- `root.descendant` remains the reconstructed first child and is not the returned second child.

The parent filesystem observations are:

- initial sorted entries are exactly `0`, `_state.ms`, and `descendant.ml`;
- initial `descendant.ml` is exactly `0/0`;
- after `load-create`, sorted entries are exactly `0`, `1`, `_state.ms`, `descendant.ml`, and `root.ml`;
- directory `1` is the only added physical child directory; `0` and `1` are directories and `1/_state.ms` is a regular file;
- `descendant.ml` remains byte-identical and exactly `0/0`;
- root `_state.ms` differs in content, and parsing with the existing `flatted` dependency shows `_keys` changing from exactly `['descendant']` to `['descendant', 'root']`.

`inspect` in another fresh process observes:

- the awaited load returns the same root;
- exactly two children are reconstructed with IDs `0/0` and `0/1`;
- both reconstructed in-memory names are `root`;
- `root.descendant` resolves to child index `0`, not index `1`;
- the sorted entry snapshot is unchanged, no directory `2` appears, `descendant.ml` remains byte-identical and exactly `0/0`, and root `_state.ms` remains byte-identical across inspection.

No modification-time inference is used.

## Verification

- Merged PR #8 baseline before editing: 6/6 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 1: 8/8 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 2: 8/8 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- `node --check` passed for all eight JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, state, coverage output, report, generated artifact, or leftover Moxley test directory appeared.
- Invalid worker argument forms were manually verified to emit their deterministic JSON status and exit `2`.
- Complete and staged changed-path sets both equal the exact three-file allowlist.
- Production source, existing tests and worker, lockfile, README, licensing files, package version, and dependencies retain their PR #8 merge-base content.
- `git diff --check` and `git diff --cached --check` passed, and the complete working-tree and staged diffs were reviewed.

## Fact and inference boundary

The tests establish that same-process duplicate creation and post-reopen duplicate creation both append a second physical child; reconstructed and newly created children have different in-memory names; the named link remains `0/0`; a later process reconstructs both physical children; and neither worker makes the second child resolve through `root.descendant`.

They do not establish that `_id` is stable persisted identity, that filesystem enumeration order is guaranteed, that either child is semantically authoritative, that duplicate creation should reject, reuse, replace, or remain unchanged, that root-state key mutation is intended, or that the format is safe or durable.

## Explicit non-goals and nonclaims

This PR does not repair or select same-process duplicate `_create(name)`, post-reopen duplicate `_create(name)`, an ensure/get-or-create API, persisted stable identity, directory-order identity, name persistence, the `root.ml` artifact, restart-safe binding, cross-process locking, concurrency, atomicity, recovery, durability, paths, symlinks, or package or format versioning.

It does not claim Moxley is production-safe or qualified for Thoth. No production behavior, dependency, package version, persisted format, migration, or release state was changed.