### PR TITLE
Characterize named child state persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible class based database system for complicated schemas",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs test/restart-load-create.test.cjs"
+    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs test/restart-load-create.test.cjs test/child-state-preimage.test.cjs"
   },
   "keywords": [
     "database",

--- a/test/child-state-preimage.test.cjs
+++ b/test/child-state-preimage.test.cjs
@@ -1,0 +1,168 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { mkdtemp, readdir, readFile, rm, stat } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+const { parse } = require('flatted');
+
+const Moxley = require('..');
+
+const CLEANUP_TIMEOUT_MS = 5_000;
+const TEST_TIMEOUT_MS = 15_000;
+
+function withTimeout(promise, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function createChildStateScenario(t) {
+  const testDirectory = await mkdtemp(
+    path.join(os.tmpdir(), 'moxley-child-state-preimage-'),
+  );
+
+  t.after(async () => {
+    await withTimeout(
+      rm(testDirectory, { recursive: true, force: true, maxRetries: 3 }),
+      'temporary directory cleanup',
+      CLEANUP_TIMEOUT_MS,
+    );
+  });
+
+  const databaseDirectory = path.join(testDirectory, 'database');
+  const databasePath = `${databaseDirectory}${path.sep}`;
+  const database = new Moxley(databasePath);
+
+  return {
+    databaseDirectory,
+    databasePath,
+    root: database.db,
+  };
+}
+
+test(
+  'named child state is written with provisional id and name',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory, root } =
+      await createChildStateScenario(t);
+    const childDirectory = path.join(databaseDirectory, '0');
+    const childStatePath = path.join(childDirectory, '_state.ms');
+    const namedLinkPath = path.join(databaseDirectory, 'descendant.ml');
+    const rootStatePath = path.join(databaseDirectory, '_state.ms');
+
+    const child = root._create('descendant');
+    const entries = (await readdir(databaseDirectory)).sort();
+    const provisionalPersistedChildState = parse(
+      (await readFile(childStatePath)).toString('utf8'),
+    );
+    const rootState = parse(
+      (await readFile(rootStatePath)).toString('utf8'),
+    );
+    const namedLinkBytes = await readFile(namedLinkPath);
+
+    assert.equal(path.resolve(child._loc), path.resolve(childDirectory));
+    assert.equal(child._id, '0/0');
+    assert.equal(child._name, 'descendant');
+    assert.deepEqual(child._keys, []);
+    assert.deepEqual(child._bindings, []);
+
+    assert.equal((await stat(childStatePath)).isFile(), true);
+    assert.equal(provisionalPersistedChildState._loc, child._loc);
+    assert.equal(
+      path.resolve(provisionalPersistedChildState._loc),
+      path.resolve(childDirectory),
+    );
+    assert.equal(provisionalPersistedChildState._id, '0');
+    assert.equal(provisionalPersistedChildState._name, 'root');
+    assert.deepEqual(provisionalPersistedChildState._keys, []);
+    assert.deepEqual(provisionalPersistedChildState._bindings, []);
+
+    assert.equal(root._children.length, 1);
+    assert.strictEqual(root._children[0], child);
+    assert.strictEqual(root.descendant, child);
+    assert.equal(namedLinkBytes.toString('utf8'), '0/0');
+    assert.deepEqual(entries, ['0', '_state.ms', 'descendant.ml']);
+    assert.equal(rootState._id, '0');
+    assert.equal(rootState._name, 'root');
+    assert.deepEqual(rootState._keys, ['descendant']);
+    assert.deepEqual(rootState._bindings, []);
+  },
+);
+
+test(
+  'reopen reconstructs the provisional child name and creates a root binding artifact',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory, databasePath, root } =
+      await createChildStateScenario(t);
+    const rootStatePath = path.join(databaseDirectory, '_state.ms');
+    const namedLinkPath = path.join(databaseDirectory, 'descendant.ml');
+    const rootLinkPath = path.join(databaseDirectory, 'root.ml');
+    const secondDirectory = path.join(databaseDirectory, '1');
+
+    root._create('descendant');
+    const beforeEntries = (await readdir(databaseDirectory)).sort();
+    const beforeRootStateBytes = await readFile(rootStatePath);
+
+    const reopenedDatabase = new Moxley(databasePath);
+    const reopenedRoot = reopenedDatabase.db;
+    const loadResult = await reopenedRoot._loadFromDir();
+    const reconstructedChild = reopenedRoot._children[0];
+    const afterEntries = (await readdir(databaseDirectory)).sort();
+    const beforeEntrySet = new Set(beforeEntries);
+    const addedEntries = afterEntries.filter(
+      (entry) => !beforeEntrySet.has(entry),
+    );
+    const afterRootStateBytes = await readFile(rootStatePath);
+    const reparsedRootState = parse(
+      afterRootStateBytes.toString('utf8'),
+    );
+
+    assert.strictEqual(loadResult, reopenedRoot);
+    assert.equal(reopenedRoot._children.length, 1);
+    assert.equal(reconstructedChild._id, '0/0');
+    assert.equal(reconstructedChild._name, 'root');
+    assert.notEqual(reconstructedChild._name, 'descendant');
+    assert.deepEqual(reconstructedChild._keys, []);
+    assert.deepEqual(reconstructedChild._bindings, []);
+    assert.strictEqual(reopenedRoot.descendant, reconstructedChild);
+    assert.deepEqual(reopenedRoot._keys, ['descendant', 'root']);
+
+    assert.deepEqual(beforeEntries, [
+      '0',
+      '_state.ms',
+      'descendant.ml',
+    ]);
+    assert.deepEqual(afterEntries, [
+      '0',
+      '_state.ms',
+      'descendant.ml',
+      'root.ml',
+    ]);
+    assert.deepEqual(addedEntries, ['root.ml']);
+    assert.equal((await readFile(rootLinkPath, 'utf8')), '0/0');
+    assert.equal((await readFile(namedLinkPath, 'utf8')), '0/0');
+    await assert.rejects(
+      stat(secondDirectory),
+      (error) => error && error.code === 'ENOENT',
+    );
+    assert.deepEqual(afterRootStateBytes, beforeRootStateBytes);
+    assert.deepEqual(reparsedRootState._keys, ['descendant']);
+  },
+);


### PR DESCRIPTION
## Scope

Base commit: `d65c66d313d784d8a66a1c1ddc713d80fb3a8b83`

Head commit: `1d43f824efc0d47a9d9f224017ccac210b1b3be5`

This branch starts directly from the authoritative PR #9 squash-merge commit: [`d65c66d313d784d8a66a1c1ddc713d80fb3a8b83`](https://github.com/dabbodev/Moxley/commit/d65c66d313d784d8a66a1c1ddc713d80fb3a8b83).

Exact changed paths:

- `package.json`
- `test/child-state-preimage.test.cjs`

The package test command now names all five test files explicitly. Production source and runtime behavior are unchanged.

## In-memory and persisted child metadata

After one `root._create('descendant')`, the finalized in-memory child refers to physical child directory `0`, has `_id` `0/0`, `_name` `descendant`, and empty `_keys` and `_bindings`. It is the only element of `root._children`, and `root.descendant` resolves to it.

The regular file `0/_state.ms` records the same physical `_loc` but provisional metadata: `_id` `0`, `_name` `root`, and empty `_keys` and `_bindings`. Source inspection and this preimage establish that the base `DB` constructor creates and saves the new child directory state before the `DN` constructor finalizes its parent-derived `_id` and requested `_name`. This does not claim that `_id: "0"` is a supported historical identity.

At that point, sorted root entries are exactly `0`, `_state.ms`, and `descendant.ml`. The named link contains exactly `0/0`. Parsed root state has `_id` `0`, `_name` `root`, `_keys` exactly `['descendant']`, and empty `_bindings`.

## Reopen and binding-artifact observations

After a fresh root completely awaits `_loadFromDir()`:

- the load resolves to the same reopened root;
- exactly one child is reconstructed with `_id` `0/0`, persisted `_name` `root`, and empty `_keys` and `_bindings`;
- `root.descendant` still resolves to that reconstructed child through `descendant.ml`;
- in-memory root `_keys` becomes exactly `['descendant', 'root']`;
- sorted root entries change only by adding `root.ml`;
- `root.ml` contains exactly `0/0`;
- directory `1` is not created;
- root `_state.ms` remains byte-identical to its pre-reopen snapshot; and
- reparsing those unchanged root-state bytes still reports `_keys` exactly `['descendant']`.

This distinguishes the in-memory root-key mutation, creation of the `root.ml` binding artifact, and unchanged on-disk root-state content. Within this characterized sequence, root state therefore remains stale relative to the new in-memory key until another save occurs.

## Byte comparisons and limits

The tests compare persisted root-state snapshots as Buffers and assert exact link contents. Byte equality establishes only equal bytes at the two observation points; it does not establish that a file was never opened or rewritten, provide a durability guarantee, or define a stable persisted format.

Each test uses a unique directory beneath the OS temporary directory, appends `path.sep` to the database path, registers unconditional cleanup bounded to 5 seconds and three removal retries, uses a 15-second test-runner timeout, sorts filesystem snapshots only for comparison, and leaves no repository or temporary test artifact.

## Verification

- Merged PR #9 baseline before editing: 8/8 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 1: 10/10 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled (`973.9781ms`).
- Final aggregate run 2: 10/10 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled (`1045.0157ms`).
- `node --check` passed for all nine JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, state, coverage output, report, generated artifact, or leftover child-state test directory appeared.
- Complete and staged changed-path sets both equaled the exact two-file allowlist.
- Production source, existing tests and workers, lockfile, README, licensing files, package version, and dependencies retain their PR #9 merge-base content.
- `git diff --check` and `git diff --cached --check` passed, and the complete working-tree and staged diffs were reviewed.

## Fact and inference boundary

Verified facts are limited to the constructor/save ordering, disagreement between finalized in-memory and persisted child metadata, re-derivation of `_id` `0/0` while consuming persisted `_name` `root`, continued targeting of `0/0` by the named link, creation of `root.ml`, mutation of in-memory root keys, and stale root-state bytes during the observed reopen sequence.

This PR does not infer a migration policy; whether old state should be rejected, rewritten, or normalized; whether `_id` should be persisted or derived; that the child-state format is stable; that `root.ml` is safe to delete automatically; or that correcting future writes would repair existing databases.

## Explicit non-goals and nonclaims

This PR does not implement a second child-state save, constructor reordering, migration, format versioning, historical-state detection, automatic `root.ml` cleanup, duplicate-name policy, ensure/get-or-create behavior, directory-order or stable identity, restart-safe binding, locking, concurrency, atomicity, recovery, durability, or package release changes.

It does not modify the completed readiness or repeated-load repairs and does not claim Moxley is production-safe or qualified for Thoth. No production behavior, dependency, package version, persisted format, migration, or release state was changed.