### PR TITLE
Persist finalized child metadata after creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ class DB { // DataBase (root node)
             newChild._template = this._childTemplate
             newChild._initTemplate()
         }
+        newChild._saveState()
         this._updateBindings(newChild)
         this._saveState()
         return newChild

--- a/test/child-state-preimage.test.cjs
+++ b/test/child-state-preimage.test.cjs
@@ -1,11 +1,18 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const { mkdtemp, readdir, readFile, rm, stat } = require('node:fs/promises');
+const {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 const { test } = require('node:test');
-const { parse } = require('flatted');
+const { parse, stringify } = require('flatted');
 
 const Moxley = require('..');
 
@@ -56,7 +63,7 @@ async function createChildStateScenario(t) {
 }
 
 test(
-  'named child state is written with provisional id and name',
+  'named child state is persisted with finalized id and name',
   { timeout: TEST_TIMEOUT_MS },
   async (t) => {
     const { databaseDirectory, root } =
@@ -68,7 +75,7 @@ test(
 
     const child = root._create('descendant');
     const entries = (await readdir(databaseDirectory)).sort();
-    const provisionalPersistedChildState = parse(
+    const persistedChildState = parse(
       (await readFile(childStatePath)).toString('utf8'),
     );
     const rootState = parse(
@@ -83,15 +90,15 @@ test(
     assert.deepEqual(child._bindings, []);
 
     assert.equal((await stat(childStatePath)).isFile(), true);
-    assert.equal(provisionalPersistedChildState._loc, child._loc);
+    assert.equal(persistedChildState._loc, child._loc);
     assert.equal(
-      path.resolve(provisionalPersistedChildState._loc),
+      path.resolve(persistedChildState._loc),
       path.resolve(childDirectory),
     );
-    assert.equal(provisionalPersistedChildState._id, '0');
-    assert.equal(provisionalPersistedChildState._name, 'root');
-    assert.deepEqual(provisionalPersistedChildState._keys, []);
-    assert.deepEqual(provisionalPersistedChildState._bindings, []);
+    assert.equal(persistedChildState._id, '0/0');
+    assert.equal(persistedChildState._name, 'descendant');
+    assert.deepEqual(persistedChildState._keys, []);
+    assert.deepEqual(persistedChildState._bindings, []);
 
     assert.equal(root._children.length, 1);
     assert.strictEqual(root._children[0], child);
@@ -106,7 +113,7 @@ test(
 );
 
 test(
-  'reopen reconstructs the provisional child name and creates a root binding artifact',
+  'reopen preserves the finalized child name without a root binding artifact',
   { timeout: TEST_TIMEOUT_MS },
   async (t) => {
     const { databaseDirectory, databasePath, root } =
@@ -125,10 +132,6 @@ test(
     const loadResult = await reopenedRoot._loadFromDir();
     const reconstructedChild = reopenedRoot._children[0];
     const afterEntries = (await readdir(databaseDirectory)).sort();
-    const beforeEntrySet = new Set(beforeEntries);
-    const addedEntries = afterEntries.filter(
-      (entry) => !beforeEntrySet.has(entry),
-    );
     const afterRootStateBytes = await readFile(rootStatePath);
     const reparsedRootState = parse(
       afterRootStateBytes.toString('utf8'),
@@ -137,32 +140,79 @@ test(
     assert.strictEqual(loadResult, reopenedRoot);
     assert.equal(reopenedRoot._children.length, 1);
     assert.equal(reconstructedChild._id, '0/0');
-    assert.equal(reconstructedChild._name, 'root');
-    assert.notEqual(reconstructedChild._name, 'descendant');
+    assert.equal(reconstructedChild._name, 'descendant');
     assert.deepEqual(reconstructedChild._keys, []);
     assert.deepEqual(reconstructedChild._bindings, []);
     assert.strictEqual(reopenedRoot.descendant, reconstructedChild);
-    assert.deepEqual(reopenedRoot._keys, ['descendant', 'root']);
+    assert.deepEqual(reopenedRoot._keys, ['descendant']);
 
     assert.deepEqual(beforeEntries, [
       '0',
       '_state.ms',
       'descendant.ml',
     ]);
-    assert.deepEqual(afterEntries, [
-      '0',
-      '_state.ms',
-      'descendant.ml',
-      'root.ml',
-    ]);
-    assert.deepEqual(addedEntries, ['root.ml']);
-    assert.equal((await readFile(rootLinkPath, 'utf8')), '0/0');
+    assert.deepEqual(afterEntries, beforeEntries);
     assert.equal((await readFile(namedLinkPath, 'utf8')), '0/0');
+    await assert.rejects(
+      stat(rootLinkPath),
+      (error) => error && error.code === 'ENOENT',
+    );
     await assert.rejects(
       stat(secondDirectory),
       (error) => error && error.code === 'ENOENT',
     );
     assert.deepEqual(afterRootStateBytes, beforeRootStateBytes);
     assert.deepEqual(reparsedRootState._keys, ['descendant']);
+  },
+);
+
+test(
+  'reopen leaves historical provisional child state bytes unchanged',
+  { timeout: TEST_TIMEOUT_MS },
+  async (t) => {
+    const { databaseDirectory, databasePath, root } =
+      await createChildStateScenario(t);
+    const childStatePath = path.join(
+      databaseDirectory,
+      '0',
+      '_state.ms',
+    );
+    const namedLinkPath = path.join(databaseDirectory, 'descendant.ml');
+    const rootLinkPath = path.join(databaseDirectory, 'root.ml');
+    const secondDirectory = path.join(databaseDirectory, '1');
+
+    const child = root._create('descendant');
+    await writeFile(
+      childStatePath,
+      stringify({
+        _loc: child._loc,
+        _id: '0',
+        _name: 'root',
+        _keys: [],
+        _bindings: [],
+      }),
+    );
+    const historicalChildStateBytes = await readFile(childStatePath);
+    const namedLinkBytes = await readFile(namedLinkPath);
+
+    const reopenedDatabase = new Moxley(databasePath);
+    const reopenedRoot = reopenedDatabase.db;
+    const loadResult = await reopenedRoot._loadFromDir();
+    const reconstructedChild = reopenedRoot._children[0];
+    const afterChildStateBytes = await readFile(childStatePath);
+    const afterNamedLinkBytes = await readFile(namedLinkPath);
+
+    assert.strictEqual(loadResult, reopenedRoot);
+    assert.equal(reopenedRoot._children.length, 1);
+    assert.equal(reconstructedChild._name, 'root');
+    assert.deepEqual(afterChildStateBytes, historicalChildStateBytes);
+    assert.deepEqual(afterNamedLinkBytes, namedLinkBytes);
+    assert.equal(afterNamedLinkBytes.toString('utf8'), '0/0');
+    assert.equal((await stat(rootLinkPath)).isFile(), true);
+    assert.equal((await readFile(rootLinkPath, 'utf8')), '0/0');
+    await assert.rejects(
+      stat(secondDirectory),
+      (error) => error && error.code === 'ENOENT',
+    );
   },
 );

--- a/test/restart-load-create.test.cjs
+++ b/test/restart-load-create.test.cjs
@@ -24,7 +24,7 @@ const EXPECTED_LOAD_CREATE = {
   loadReturnedSameRoot: true,
   beforeChildCount: 1,
   beforeChildIds: ['0/0'],
-  beforeChildNames: ['root'],
+  beforeChildNames: ['descendant'],
   beforeNamedChildIndex: 0,
   beforeNamedIsReconstructed: true,
   createdReturnedObject: true,
@@ -33,7 +33,7 @@ const EXPECTED_LOAD_CREATE = {
   createdName: 'descendant',
   afterChildCount: 2,
   afterChildIds: ['0/0', '0/1'],
-  afterChildNames: ['root', 'descendant'],
+  afterChildNames: ['descendant', 'descendant'],
   afterFirstIsReconstructed: true,
   afterSecondIsCreated: true,
   afterNamedChildIndex: 0,
@@ -46,7 +46,7 @@ const EXPECTED_INSPECT = {
   loadReturnedSameRoot: true,
   childCount: 2,
   childIds: ['0/0', '0/1'],
-  childNames: ['root', 'root'],
+  childNames: ['descendant', 'descendant'],
   namedChildIndex: 0,
   namedIsFirst: true,
   namedIsSecond: false,
@@ -262,7 +262,6 @@ test(
       '1',
       '_state.ms',
       'descendant.ml',
-      'root.ml',
     ]);
     assert.deepEqual(addedDirectories, ['1']);
     assert.equal(
@@ -283,8 +282,12 @@ test(
     );
     assert.deepEqual(finalNamedLinkBytes, initialNamedLinkBytes);
     assert.equal(finalNamedLinkBytes.toString('utf8'), '0/0');
-    assert.notDeepEqual(finalRootStateBytes, initialRootStateBytes);
-    assert.deepEqual(finalRootState._keys, ['descendant', 'root']);
+    await assert.rejects(
+      stat(path.join(databaseDirectory, 'root.ml')),
+      (error) => error && error.code === 'ENOENT',
+    );
+    assert.deepEqual(finalRootStateBytes, initialRootStateBytes);
+    assert.deepEqual(finalRootState._keys, ['descendant']);
   },
 );
 
@@ -318,6 +321,12 @@ test(
     const afterInspectRootStateBytes = await readFile(rootStatePath);
 
     assert.deepEqual(afterInspectEntries, beforeInspectEntries);
+    assert.deepEqual(beforeInspectEntries, [
+      '0',
+      '1',
+      '_state.ms',
+      'descendant.ml',
+    ]);
     await assert.rejects(
       stat(path.join(databaseDirectory, '2')),
       (error) => error && error.code === 'ENOENT',


### PR DESCRIPTION
## Scope

Base commit: `515054802683a50d1daf8b958d150c3c1f73561e`

Head commit: `81f97f8d66958e4f15e07b1e5d7d82e9faba6199`

This branch starts directly from the authoritative PR #10 squash-merge commit: [`515054802683a50d1daf8b958d150c3c1f73561e`](https://github.com/dabbodev/Moxley/commit/515054802683a50d1daf8b958d150c3c1f73561e).

Exact changed paths:

- `index.js`
- `test/child-state-preimage.test.cjs`
- `test/restart-load-create.test.cjs`

No package manifest, lockfile, worker, dependency, version, licensing file, or unrelated production method changed.

## Why `_create()` owns the additional save

`DB._create(name)` now calls the new child’s existing `_saveState()` exactly once after construction has finalized the child’s `_loc`, parent-derived `_id`, requested `_name`, `_root`, and `_parent`, and after any existing child-template initialization. Binding updates and the existing parent save remain in their original order after that child save.

The save belongs to `_create()` rather than `DB` or `DN` construction because `_loadFromDir()` also constructs `DN` instances. Constructor-level saving could silently rewrite historical provisional child state during ordinary reopen. This change leaves `_scanLocation()`, constructor ordering, `_saveState()`, `_loadFromDir()`, and `_store()` unchanged.

## New-write behavior

After one `_create('descendant')`, both finalized in-memory metadata and `0/_state.ms` now record:

- the same physical child directory `0` in `_loc`;
- `_id` `0/0`;
- `_name` `descendant`;
- empty `_keys`; and
- empty `_bindings`.

The child remains the sole element of `_children`, `root.descendant` resolves to it, `descendant.ml` remains exactly `0/0`, root entries remain `0`, `_state.ms`, and `descendant.ml`, and root state retains `_keys` exactly `['descendant']`.

A completed reopen reconstructs one child with `_id` `0/0` and `_name` `descendant`. The named lookup still resolves to it, in-memory root keys remain exactly `['descendant']`, the root entry snapshot and root-state bytes remain unchanged, and neither `root.ml` nor directory `1` is created.

## Historical-state non-migration guard

A test deliberately overwrites only `0/_state.ms` with the previously characterized provisional values `_id: '0'`, `_name: 'root'`, and empty keys/bindings while retaining the child’s physical `_loc`. This is a handcrafted regression fixture, not a supported format-version declaration.

Ordinary `_loadFromDir()` leaves those exact child-state bytes unchanged. The reconstructed child still consumes name `root`, `descendant.ml` remains byte-identical and exactly `0/0`, the historical behavior can still create `root.ml`, and directory `1` is not created. No historical-state detection, rewrite, normalization, rejection, or cleanup was added.

## Updated fresh-process observations

In the existing fresh-process load-create sequence:

- the reconstructed first child now has name `descendant`;
- the distinct newly created child remains `_id` `0/1` with name `descendant`;
- the ordered child names are `['descendant', 'descendant']`;
- the named lookup remains on the reconstructed first child;
- the only added physical child directory is `1`;
- root entries are exactly `0`, `1`, `_state.ms`, and `descendant.ml`;
- `root.ml` is absent;
- `descendant.ml` remains byte-identical and exactly `0/0`; and
- root `_state.ms` remains byte-identical with parsed keys exactly `['descendant']`.

A second fresh-process inspection reconstructs both children with names `['descendant', 'descendant']`, adds no entry or directory `2`, and preserves the original named binding. The separate duplicate child remains characterized behavior; this PR does not select or repair duplicate-name semantics.

## Persisted-value compatibility and failure boundary

`_create()` performs one additional child-state write after finalization. Newly created state keeps the same filename and object shape but corrects `_id` and `_name` from provisional to finalized values. Existing legitimate root/link bytes are not migrated, ordinary loading does not rewrite historical provisional child state, and newly created children no longer synthesize `root.ml` on reopen.

This is an observable persisted-value correction, not a claim that the format is versioned or stable. No migration exists, and no package version or release is selected.

The final child-state save can fail after the child directory, provisional state, and named link already exist. The original error propagates. This PR adds no rollback, cleanup, retry, atomicity, recovery, or durability guarantee for that partial-artifact boundary.

## Verification

- Merged PR #10 negative baseline before editing: 10/10 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled.
- Final aggregate run 1: 11/11 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled (`1221.4192ms`).
- Final aggregate run 2: 11/11 passing, 0 failures, 0 skipped, 0 todo, 0 cancelled (`879.0626ms`).
- `node --check` passed for all nine JavaScript/CJS files.
- `package.json` and `package-lock.json` parsed successfully.
- No repository-local database, state, coverage output, report, generated artifact, or leftover Moxley test directory appeared.
- Complete and staged changed-path sets both equaled the exact three-file allowlist.
- Protected paths, package metadata, dependencies, version, README, and licensing files retain their PR #10 merge-base content.
- `git diff --check` and `git diff --cached --check` passed, and the complete working-tree and staged diffs were reviewed.

## Explicit non-goals and nonclaims

This PR does not implement or select historical-state migration, rejection, or automatic normalization; duplicate `_create(name)` policy; ensure/get-or-create behavior; stable persisted identity; directory-order identity; automatic `root.ml` cleanup for existing databases; `_store()` changes; path or symlink policy; locking; concurrency; atomicity; recovery; durability; package or format versioning; npm publication; or release behavior.

It does not claim existing databases are repaired, that historical provisional state is supported, that Moxley is production-safe, or that Moxley is qualified for Thoth. Dependencies, package version, historical bytes, migration state, and release state are unchanged.