### PR TITLE
Add private native classifier loader

### DIFF
--- a/STATE_COMPATIBILITY.md
+++ b/STATE_COMPATIBILITY.md
@@ -2,11 +2,11 @@
 
 Status: Marker separability, future node identity, derived runtime-location
 authority, root-input lexical rules, persisted-name grammar, filesystem
-canonicalization and containment policy, the Windows reparse-classification
-mechanism, and the future native build and private internal-loader contract are
-selected; test-only native characterization is recorded, but no production
-native implementation or traversal integration exists and complete version-1
-qualification remains a no-go.
+canonicalization and containment policy, and the Windows reparse-classification
+mechanism are selected. The private production native source, explicit build
+and clean tooling, and private one-shot loader are implemented and isolated;
+traversal integration remains absent and complete version-1 qualification
+remains a no-go.
 Date: 2026-07-31
 Historical behavior baseline: `518ab5ab58500a84246770e8ef0180856e127abd`
 Discriminator decision input baseline: `635a7c09bcca63c3abbb52d5c2fbbce4b87a9817`
@@ -21,6 +21,8 @@ Windows reparse decision input baseline:
 `9a33fca1ed185516b3c6433369a8279bb15cb9a9`
 Native build and internal-loader contract input baseline:
 `33822da91018be3ec8e2e8c76d4cf03036861473`
+Native build and clean implementation baseline:
+`939160031487b44c9255947051b363a1eede18bd`
 Decision authority: David Giles, sole owner of Moxley
 
 These repository baselines are evidence and decision inputs. None is a
@@ -1784,12 +1786,20 @@ behavior.
 
 ## 58. Native build and internal-loader authority and evidence labels
 
-**Currently implemented characterization:** PR #25 completed the test-only
-slice described in section 57 and was squash-merged as
-`33822da91018be3ec8e2e8c76d4cf03036861473`. The authoritative merge adds the
-disposable source `test/native/windows-reparse-classifier.c`, its same-file
-worker and test harness, and the test-script entry that runs the harness. It
-does not add production native or JavaScript source.
+**Currently implemented characterization:** PR #25 completed the original
+test-only native characterization and was squash-merged as
+`33822da91018be3ec8e2e8c76d4cf03036861473`. PR #26 selected the build and
+loader contract on the later authoritative baseline
+`b622dfc2f7de5dbe1d9062e3b4b01132209960c0`.
+
+**Currently implemented boundary:** PR #27 was reviewed at exact head
+`105710054dc6047e37d64ecc0b4ee417f39f453f` and squash-merged as
+`939160031487b44c9255947051b363a1eede18bd`. It promotes the characterized C
+source to `native/windows-reparse-classifier.c`, removes the test-only C path,
+adds the explicit build and clean drivers, and adds their isolated lifecycle
+tests. That authoritative merge has 60 passing tests, 14 tracked
+JavaScript/CJS/MJS files, one production C file, 19 persisted fixtures, three
+Markdown files, and two JSON manifests.
 
 **Currently implemented characterization:** The authority audit for this
 contract inspected complete `STATE_COMPATIBILITY.md`, complete `index.js`, both
@@ -1801,13 +1811,14 @@ tracked package layout. The merged baseline has 50 passing tests, 11 tracked
 JavaScript/CJS/MJS files, one test-only C file, 19 persisted fixtures, three
 Markdown files, and two JSON manifests.
 
-**Currently implemented characterization:** `index.js` remains the only
-production entry point. `test/native/windows-reparse-classifier.c` remains
-test-only. There is no production native source, internal loader, build or
-clean driver, `binding.gyp`, native dependency, package export, lifecycle
-build, or generated output. `build/Release` is already ignored. Package
-installation does not build a native addon. `npm test` builds only disposable
-test variants in a task-owned OS-temporary directory and removes them.
+**Currently implemented boundary:** `index.js` remains the only package entry
+point. The production C source, explicit build and clean drivers, and private
+loader now exist, but none is imported by `index.js` or exposed through a
+package export. There is still no `binding.gyp`, native dependency, lifecycle
+build, prebuild, downloader, or committed generated output. Package
+installation does not build a native addon. The explicit tests compile both
+characterization variants and one qualified production addon, use bounded
+children for genuine addon loading, and remove every generated path.
 
 The following labels govern every item in this contract:
 
@@ -1815,32 +1826,34 @@ The following labels govern every item in this contract:
   separately authorized implementation. It is not current behavior.
 - **Currently implemented characterization** is evidence present at the input
   baseline. It is not production qualification.
-- **Deferred implementation** identifies work that this documentation-only
-  slice does not perform.
+- **Currently implemented boundary** is repository code and isolated test
+  behavior present in the current slice. It is not traversal qualification.
+- **Deferred implementation** identifies work that the current bounded slices
+  do not perform.
 - **Explicit nonclaim** states a guarantee, threat model, runtime behavior, or
   distribution decision that this contract does not establish.
 
-**Explicit nonclaim:** Nothing in sections 58 through 72 changes current
-runtime behavior, authorizes production traversal, creates a build artifact,
-or qualifies complete Windows version-1 support. The continuing disposition is
-**no-go**.
+**Explicit nonclaim:** Nothing in sections 58 through 72 connects native
+classification to Moxley runtime behavior, authorizes production traversal,
+commits a build artifact, or qualifies complete Windows version-1 support. The
+continuing disposition is **no-go**.
 
-## 59. Ownership and exact future paths
+## 59. Ownership and exact private paths
 
-**Selected future contract:** The one authoritative production C source is:
+**Currently implemented boundary:** The one authoritative production C source
+is:
 
 ```text
 native/windows-reparse-classifier.c
 ```
 
-The later implementation must promote and adapt the characterized test source
-into that single production source. Production and test copies must not remain
-independently maintained. After promotion, native characterization tests must
-compile the production source, and the old test-only C source must be removed
-in the same separately authorized implementation. The production source
-remains original Moxley code under Apache-2.0.
+PR #27 promoted and adapted the characterized test source into that single
+production source. The characterization tests compile it for both the normal
+and characterization-only injected variants, and the old test-only C path is
+absent. The production source remains original Moxley code under Apache-2.0.
 
-**Selected future contract:** The exact future internal paths are:
+**Currently implemented boundary:** The exact private source and generated
+paths are:
 
 - production native source:
   `native/windows-reparse-classifier.c`;
@@ -1855,9 +1868,9 @@ remains original Moxley code under Apache-2.0.
 - generated exclusive build lock:
   `build/Release/.moxley-windows-reparse-build.lock`.
 
-**Deferred implementation:** None of those future paths is created by this
-contract. Source promotion, removal of the old test source, and every build,
-clean, loader, or test change require separate authorization.
+The four source paths exist. The generated binary, receipt, lock, and staging
+directory exist only during an explicit build/test lifecycle and remain
+ignored and absent after successful clean and test completion.
 
 **Explicit nonclaim:** Listing a path does not make it a package export,
 public API, installed artifact, published file, or currently supported runtime
@@ -1865,23 +1878,23 @@ component.
 
 ## 60. Dependency direction and visibility
 
-**Selected future contract:** The only permitted dependency direction is:
+**Currently implemented boundary:** The present and only permitted dependency
+direction is:
 
 ```text
-future hardened traversal
+future hardened traversal (not implemented)
   -> lib/internal/windows-reparse-classifier.cjs
     -> build/Release/moxley-windows-reparse.node
       -> Windows system APIs
 ```
 
-No reverse dependency is permitted. The first build/loader implementation
-slice must not import the loader from `index.js` and must not expose it. Only a
-later separately authorized hardened traversal component may depend on the
-internal loader. The loader may depend on the exact generated addon. The addon
-must not depend on Moxley JavaScript state, persisted formats, Thoth,
-Yggdrasil, or an adapter.
+No reverse dependency is present or permitted. `index.js` does not import or
+expose the loader. Only a later separately authorized hardened traversal
+component may depend on it. The loader depends only on the exact generated
+addon and receipt. The addon does not depend on Moxley JavaScript state,
+persisted formats, Thoth, Yggdrasil, or an adapter.
 
-**Selected future contract:** The loader and addon remain private
+**Currently implemented boundary:** The loader and addon remain private
 implementation details. No package export, documented public method,
 caller-accessible native API, or direct import by another package or repository
 is approved.
@@ -1889,12 +1902,13 @@ is approved.
 **Deferred implementation:** Traversal integration and any mapping from native
 classification to traversal behavior remain later slices.
 
-**Explicit nonclaim:** This dependency diagram does not claim that a hardened
-traversal, internal loader, generated addon, adapter, or Thoth consumer exists.
+**Explicit nonclaim:** This dependency diagram does not claim that hardened
+traversal, an adapter, or a Thoth consumer exists. The generated addon is local
+build output rather than a tracked or distributed artifact.
 
 ## 61. Explicit build and clean commands
 
-**Selected future contract:** The future package scripts are exactly:
+**Currently implemented boundary:** The package scripts are exactly:
 
 ```text
 npm run build:native:windows
@@ -1902,17 +1916,15 @@ npm run clean:native:windows
 ```
 
 They are explicit operator commands. Native building is prohibited from
-`install`, `preinstall`, `postinstall`, `prepare`, `prepublish`, `npm test`,
-ordinary `require("moxley-db")`, and loader invocation. No runtime or package
-command may download headers, compilers, SDKs, prebuilds, or binaries.
+`install`, `preinstall`, `postinstall`, `prepare`, `prepublish`, ordinary
+`require("moxley-db")`, and loader invocation. The isolated native lifecycle
+tests invoke the same explicit build driver and clean all output. No runtime or
+package command downloads headers, compilers, SDKs, prebuilds, or binaries.
 
-**Currently implemented characterization:** `package.json` has only the `test`
-script, has no lifecycle script, and has no production native build command.
-There is no `binding.gyp`, so package installation has no implicit repository
-addon build input.
-
-**Deferred implementation:** The two manifest scripts and their driver files
-are not added in this documentation-only slice.
+**Currently implemented boundary:** `package.json` contains the two explicit
+commands and the serial test command. It has no lifecycle script. There is no
+`binding.gyp`, so package installation has no implicit repository addon build
+input.
 
 **Explicit nonclaim:** The selected command names do not authorize install-time
 building, automatic repair, loader-triggered compilation, or any network
@@ -1920,9 +1932,9 @@ access.
 
 ## 62. Build mechanism and exact initial target
 
-**Selected future contract:** The build uses direct source-only MSVC
-compilation, consistent with the accepted PR #25 characterization. The future
-build driver must:
+**Currently implemented boundary:** The build uses direct source-only MSVC
+compilation, consistent with the accepted PR #25 characterization. The build
+driver:
 
 - support only `win32` / `x64`;
 - require the approved exact Node and Node-API boundary;
@@ -1944,7 +1956,7 @@ build driver must:
   staging directory and exact owned lock, while a failure at or after the first
   final promotion preserves final-output and lock evidence.
 
-**Selected future contract:** The initial exact qualified build target is
+**Currently implemented boundary:** The exact authenticated build target is
 Windows 11 Home 25H2 build `26200.8875`, `win32` / `x64`, fixed local NTFS,
 Node `v24.13.0`, modules ABI 137, Node runtime Node-API 10, and the stable
 Node-API version 8 addon surface. The accepted toolchain evidence is Visual
@@ -1959,23 +1971,22 @@ The accepted x64 `Kernel32.Lib` is 311,908 bytes with SHA-256
 eligibility boundary only. It is not automatic qualification. Every exact Node
 patch requires an exact build receipt and separate verification before use.
 
-**Currently implemented characterization:** PR #25 directly compiles normal
-and injected test-only variants with the exact approved local toolchain, loads
-them only in bounded same-file child workers, and removes every task-owned
-build and filesystem path. It does not build a production addon.
-
-**Deferred implementation:** Exact discovery mechanics, signing verification,
-the final staging-directory spelling, receipt production, promotion logic, and
-production build-driver errors remain implementation work constrained by this
-contract.
+**Currently implemented boundary:** The characterization suite directly
+compiles normal and injected variants from the production source. The explicit
+production driver never defines the characterization-only failure macro. It
+authenticates the exact host, signed compiler and linker, SDK declarations,
+five cached Node headers, `node.lib`, and `Kernel32.Lib` before a warning-free
+compile/link. It uses bounded subprocesses without shell interpolation and
+performs no download.
 
 **Explicit nonclaim:** Node-API ABI stability does not qualify another Node
 patch, toolchain, SDK, OS build, filesystem, architecture, or generated binary.
 
 ## 63. Collision failure, locking, staging, and promotion
 
-**Selected future contract:** Generation is collision-failing. A build must not
-overwrite or silently replace an existing final binary, receipt, or lock. If
+**Currently implemented boundary:** Generation is collision-failing. A build
+does not overwrite or silently replace an existing final binary, receipt, or
+lock. If
 either final output already exists, the build fails and instructs the operator
 to run the explicit clean command first. Concurrent builds are unsupported and
 must fail through exclusive creation of the exact lock file. An abandoned lock
@@ -1983,7 +1994,7 @@ is not automatically removed. The explicit clean command is the only approved
 recovery for an abandoned task-owned lock, and only after verifying that no
 build process is active. No retry loop or automatic recovery is approved.
 
-**Selected future contract:** The build sequence is exactly:
+**Currently implemented boundary:** The build sequence is exactly:
 
 1. Authenticate the platform, filesystem boundary, toolchain, SDK, Node
    inputs, production source, package-relative output paths, and output
@@ -1997,10 +2008,11 @@ build process is active. No retry loop or automatic recovery is approved.
 7. Produce and validate the canonical receipt in staging.
 8. Immediately before promotion, require both final output paths still to be
    absent.
-9. Promote the binary into its absent final destination using the selected
-   collision-failing rename primitive.
-10. Promote the receipt into its absent final destination using the selected
-    collision-failing rename primitive.
+9. Promote the binary into its absent final destination with a
+   collision-failing same-volume hard-link creation, then remove the staged
+   link.
+10. Promote the receipt by the same no-replace hard-link operation, then remove
+    the staged link.
 11. While the exclusive lock is still held:
     - reopen the final receipt;
     - require exact canonical bytes, schema, versions, paths, types, and
@@ -2015,53 +2027,56 @@ build process is active. No retry loop or automatic recovery is approved.
 14. Return build success without performing another acceptance check outside
     the lock.
 
-**Selected future contract:** No cooperating build or clean command may mutate
-generated state while step 11 executes. The lock is released only after final
+**Currently implemented boundary:** No cooperating build or clean command may
+mutate generated state while step 11 executes. The lock is released only after final
 acceptance and staging cleanup succeed. There is no post-unlock acceptance
 step. Build success is not reported before successful lock release. A
 lock-release failure means the command fails and reports the retained exact
 lock; it does not report successful completion.
 
-**Selected future contract:** Each promotion rename is individually atomic on
-the supported fixed local NTFS boundary and must fail rather than replace an
-existing destination. The binary/receipt pair is not transactionally atomic. A
-crash between promotions leaves an incomplete pair, which the loader must
-reject.
+**Currently implemented boundary:** Each final hard-link creation is an
+individual collision-failing no-replace operation on the supported fixed local
+NTFS boundary. The binary/receipt pair is not transactionally atomic. A crash
+between promotions leaves an incomplete pair, which the loader rejects.
 
-**Selected future contract — before the first final promotion:** For a handled
-failure after acquiring the lock but before step 9, the build removes only the
+**Currently implemented boundary — before the first final promotion:** For a
+handled failure after acquiring the lock but before step 9, the build removes only the
 exact authenticated staging directory if it was created, releases only the
 exact owned lock, leaves both final output paths absent, reports failure, and
 does not retry. If safe staging cleanup or lock release fails, it reports the
 retained exact path and fails without broadening cleanup.
 
-**Selected future contract — at or after the first final promotion:** For a
-handled failure at or after step 9, the build does not delete, overwrite,
+**Currently implemented boundary — at or after the first final promotion:**
+For a handled failure at or after step 9, the build does not delete, overwrite,
 replace, or roll back either final output; does not report build success;
 leaves the lock present as incomplete-build evidence; preserves any incomplete
 binary/receipt pair; and stops without retry. A later explicit clean command is
 required. Clean may remove the incomplete generated state and abandoned lock
 only after independently proving that no build process remains active.
 
-**Selected future contract — crash behavior:** A process crash may leave
+**Currently implemented boundary — crash behavior:** A process crash may leave
 staging, the lock, only the final binary, both final outputs without completed
 verification, or another incomplete subset of generated state. The loader
 rejects every missing, incomplete, invalid, or mismatched final pair. The
 explicit clean command is the only selected recovery. No rollback, automatic
 repair, stale-lock timeout, PID-reuse inference, retry, or resume is selected.
 
-**Deferred implementation:** The later implementation must select one exact
-contained staging path and a collision-failing Windows promotion primitive
-that satisfies this sequence. This document neither creates that staging path
-nor selects a retry mechanism.
+**Currently implemented boundary:** The build starts the deterministic
+package-root-derived Windows named-pipe lease before exclusively creating the
+exact canonical lock file. It then creates one random
+`.moxley-windows-reparse-stage-<32 lowercase hex>` directory directly under
+`build/Release`. Clean connects once to the exact pipe recorded by a strictly
+validated lock: a successful connection proves an active cooperating build;
+an absent pipe makes the validated lock abandoned evidence. Neither driver
+uses PID, age, staleness, wait, retry, or PID-reuse inference.
 
-**Explicit nonclaim:** The lock coordinates only the future cooperating build
+**Explicit nonclaim:** The lock coordinates only the cooperating build
 and clean drivers. It is not a database lock, a hostile-local-user defense, a
 transaction, or crash recovery.
 
 ## 64. Canonical generated receipt
 
-**Selected future contract:** The generated, ignored, nonauthoritative local
+**Currently implemented boundary:** The generated, ignored, nonauthoritative local
 receipt has this exact logical key set and key order:
 
 ```json
@@ -2100,9 +2115,10 @@ receipt has this exact logical key set and key order:
 ```
 
 The zero and empty values are type placeholders only. They are not authorized
-emitted values. The future builder must populate nonempty exact evidence.
+emitted values. The builder populates every placeholder with authenticated
+nonempty evidence.
 
-**Selected future contract:** Receipt bytes are strict UTF-8 without BOM, with
+**Currently implemented boundary:** Receipt bytes are strict UTF-8 without BOM, with
 one final LF, the exact key set and order above, no duplicate or additional
 keys, integers for byte lengths and versions, positive safe-integer byte
 lengths for emitted source/import-library/artifact evidence, lowercase
@@ -2110,7 +2126,7 @@ lengths for emitted source/import-library/artifact evidence, lowercase
 The receipt contains no timestamp, username, absolute path, environment
 variable, hostname, secret, or unrelated machine state.
 
-**Selected future contract:** The exact required Node-header set is
+**Currently implemented boundary:** The exact required Node-header set is
 `node_api.h`, `node_api_types.h`, `js_native_api.h`,
 `js_native_api_types.h`, and `node_version.h`. The headers-tree hash algorithm
 is:
@@ -2132,14 +2148,12 @@ a new `receiptVersion`. `nativeContractVersion` is independently versioned; any
 native wire or export-contract change requires a new
 `nativeContractVersion`.
 
-**Currently implemented characterization:** PR #25 requires the exact five
-local header names and validates the matching Node version and ABI macros. It
-separately authenticates the accepted `node.lib` and `Kernel32.Lib` byte
-lengths and hashes before disposable compilation. It does not hash the headers
-as a canonical tree and does not emit this production receipt.
-
-**Deferred implementation:** Receipt serialization, canonical validation, and
-the first populated receipt are deferred to the implementation slice.
+**Currently implemented boundary:** The build driver independently hashes the
+five-file header ledger, authenticates the accepted `node.lib` and
+`Kernel32.Lib` lengths and hashes, and emits the canonical populated receipt.
+The loader independently enforces the receipt framing, exact keys and order,
+versions, target, paths, types, bounds, fixed toolchain and import-library
+evidence, and running Node compatibility before reading and hashing the addon.
 
 **Explicit nonclaim:** The receipt is reproducibility and accidental-mismatch
 evidence. It is not signed provenance, a trust anchor, or protection against an
@@ -2147,18 +2161,18 @@ attacker who can replace both the binary and receipt.
 
 ## 65. Explicit clean behavior
 
-**Selected future contract:** The clean driver resolves every path from the
+**Currently implemented boundary:** The clean driver resolves every path from the
 Moxley package root, never from the current working directory. It may operate
 only on the exact generated binary, receipt, and lock paths from section 59. It
 may additionally remove only the exact authenticated staging directory created
 by the build driver.
 
-**Selected future contract:** Explicit clean is the only selected recovery for
+**Currently implemented boundary:** Explicit clean is the only selected recovery for
 post-promotion or crash-retained incomplete generated state and an abandoned
 lock. It is not invoked automatically by the build. It may remove that state
 only after independently proving that no build process remains active.
 
-**Selected future contract:** Before removal, clean must reject a symbolic
+**Currently implemented boundary:** Before removal, clean rejects a symbolic
 link, junction, detectable reparse point, unexpected filesystem type,
 containment mismatch, unauthenticated staging directory, or unknown staging
 entry. It must never recursively delete `build`, `build/Release`, the
@@ -2167,9 +2181,12 @@ the exact generated targets are not deletion authority. If clean cannot prove
 that a build process is inactive, it fails. It reports exactly what it removed
 and treats already-absent exact outputs as idempotent success.
 
-**Deferred implementation:** The active-build proof, exact staging
-authentication record, safe removal primitives, and stable clean-command
-output remain implementation details that must preserve these bounds.
+**Currently implemented boundary:** The canonical lock contains only its exact
+format/version, package-root repository key, deterministic pipe name, one
+relative staging name, and a lowercase random nonce. Clean strictly validates
+that record, the non-following metadata and identity of every approved target,
+the staging inventory, and post-removal absence. Its success output contains
+only ordinal repository-relative approved paths.
 
 **Explicit nonclaim:** Clean removes generated local build state only. It is
 not rollback of database state, package installation, runtime behavior, or a
@@ -2177,7 +2194,7 @@ published artifact.
 
 ## 66. Private synchronous loader contract
 
-**Selected future contract:** The one future private loader function is:
+**Currently implemented boundary:** The one private loader function is:
 
 ```js
 loadWindowsReparseClassifier()
@@ -2206,7 +2223,7 @@ field order:
 }
 ```
 
-**Selected future contract:** The loader must, in order:
+**Currently implemented boundary:** The loader, in order:
 
 1. Resolve all paths from its own package location, never `cwd`, environment
    expansion, or caller input.
@@ -2227,7 +2244,7 @@ field order:
     exactly the JavaScript wrapper function `classify`.
 12. Never build, clean, download, retry, or fall back.
 
-**Selected future contract:** On every wrapper call, the wrapper must:
+**Currently implemented boundary:** On every wrapper call, the wrapper:
 
 1. Invoke the cached native `classify` function exactly once.
 2. Receive the native result synchronously.
@@ -2236,7 +2253,7 @@ field order:
    validated fields.
 5. Never return the original native object.
 
-**Selected future contract:** An accepted result is an ordinary, non-null
+**Currently implemented boundary:** An accepted result is an ordinary, non-null
 object whose prototype is exactly `Object.prototype`, with exactly the five own
 enumerable string-keyed data properties shown above in that order. Arrays,
 primitives, proxies, additional or missing string keys, symbol keys, inherited
@@ -2251,7 +2268,7 @@ only from validated data descriptors, never by repeated property access. It
 must not spread, stringify, log, mutate, freeze, expose, or retain a malformed
 native object.
 
-**Selected future contract:** `outcome` must be a primitive string exactly
+**Currently implemented boundary:** `outcome` must be a primitive string exactly
 equal to `ordinary`, `reparse`, or `capability-gap`. Each of
 `fileAttributes`, `reparseTag`, `win32Error`, and `closeWin32Error` must be a
 JavaScript number that is finite, is an integer, and is between `0` and
@@ -2275,30 +2292,32 @@ nonzero tag, and `ERROR_INVALID_DATA`—therefore remains a valid
 `capability-gap`. Every field, shape, descriptor, or outcome-consistency
 mismatch is invalid native-result evidence.
 
-**Selected future contract:** For a valid native result, the wrapper creates a
+**Currently implemented boundary:** For a valid native result, the wrapper creates a
 new JavaScript object, copies only the five validated primitive values in the
 exact key order shown above, freezes the new object, and returns it
 synchronously. It does not return, freeze, mutate, or expose the native-owned
 object. A valid `capability-gap` result is returned as a valid classification
 result; mapping it to traversal behavior remains deferred.
 
-**Selected future contract:** Loading is one-shot per process. The first load
+**Currently implemented boundary:** Loading is one-shot per process. The first load
 success is cached. The first load failure is terminal for that process. No
 retry occurs after generated output changes; process restart is required for
 another load attempt. This prevents silent mid-process capability substitution.
 
-**Deferred implementation:** The validation policy, accepted shape,
-consistency rules, result-invalid code, and poisoned-state behavior are
-selected by this contract. The JavaScript code and tests that enforce them,
-loader caching, and traversal-specific result mapping remain deferred to
-separately authorized implementation.
+**Currently implemented boundary:** The private module exports only one frozen
+object containing `loadWindowsReparseClassifier`. It exports no raw native
+function, validator, cache, error class, path, receipt parser, artifact detail,
+or test hook. Isolated child processes verify the one-shot load cache, exact
+result copying, closed validation reasons, and permanent post-invalid-result
+poisoning. Traversal-specific result mapping remains deferred to a separately
+authorized implementation.
 
 **Explicit nonclaim:** Receipt verification followed by `require()` does not
 eliminate the filesystem race between verification and native loading.
 
 ## 67. Internal loader errors
 
-**Selected future contract:** The internal error name is
+**Currently implemented boundary:** The internal error name is
 `MoxleyNativeCapabilityError`. The stable private codes are:
 
 - `MOXLEY_NATIVE_PLATFORM_UNSUPPORTED`;
@@ -2309,14 +2328,24 @@ eliminate the filesystem race between verification and native loading.
 - `MOXLEY_NATIVE_EXPORT_INVALID`; and
 - `MOXLEY_NATIVE_RESULT_INVALID`.
 
-**Selected future contract:** The loader retains original filesystem, JSON,
-hashing, and `require` failures as `cause` where applicable. Stable messages do
+The selected stable private outer messages are, respectively:
+
+- `Native classifier is unsupported on this platform.`
+- `Native classifier artifact is missing.`
+- `Native classifier receipt is invalid.`
+- `Native classifier artifact integrity check failed.`
+- `Native classifier failed to load.`
+- `Native classifier export is invalid.`
+- `Native classifier returned invalid result evidence.`
+
+**Currently implemented boundary:** The loader retains original filesystem,
+JSON, hashing, and `require` failures as `cause` where applicable. Stable messages do
 not expose absolute build paths. A failure is never converted into JavaScript
 `lstat`, `realpath`, a permissive classification, or any other fallback. These
 codes are private implementation contracts, not public package API.
 
-**Selected future contract:** `MOXLEY_NATIVE_RESULT_INVALID` is used only when
-the successfully loaded native function returns malformed, inconsistent,
+**Currently implemented boundary:** `MOXLEY_NATIVE_RESULT_INVALID` is used only
+when the successfully loaded native function returns malformed, inconsistent,
 throwing, or otherwise invalid result evidence. Its stable message is
 `Native classifier returned invalid result evidence.` It contains no absolute
 path or raw native value. The error retains only a newly created bounded
@@ -2343,8 +2372,8 @@ retain the malformed object or an exception obtained from it, invoke arbitrary
 serialization, invoke getters, or include stack material from the returned
 value, host state, or environment data.
 
-**Selected future contract:** A successfully loaded classifier begins usable.
-A valid `ordinary`, `reparse`, or `capability-gap` result does not poison it.
+**Currently implemented boundary:** A successfully loaded classifier begins
+usable. A valid `ordinary`, `reparse`, or `capability-gap` result does not poison it.
 The first `MOXLEY_NATIVE_RESULT_INVALID` disposition permanently poisons the
 cached classifier for that process, and the malformed result is never returned.
 Subsequent wrapper calls do not invoke native code again and fail with the same
@@ -2361,25 +2390,29 @@ fail-closed and restart-required.
 Build-driver failures, including a busy lock or toolchain rejection, remain
 build-command concerns and are not loader error codes.
 
-**Explicit nonclaim:** Selecting internal names and codes does not expose them
-from `index.js`, promise stability to external callers, or implement an error
-class in this slice.
+**Explicit nonclaim:** Implementing the private names, codes, and error class
+does not expose them from `index.js` or promise stability to external callers.
+The error class remains private and unexported.
 
 ## 68. Loader bootstrapping and security boundary
 
-**Selected future contract:** The generated build directory is trusted local
-build output under the operator's filesystem permissions. The loader uses
+**Currently implemented boundary:** The generated build directory is trusted
+local build output under the operator's filesystem permissions. The loader uses
 package-relative resolution and receipt hashing to detect missing,
 incomplete, or accidentally mismatched output and rejects an incomplete
 binary/receipt pair.
 
-**Currently implemented characterization:** The addon cannot classify its own
-binary before it has been loaded. JavaScript `lstat` cannot prove absence of
-every generic Windows reparse category. PR #25 proves only bounded test-worker
-loading and classification on the accepted host.
+**Currently implemented boundary:** The loader validates the receipt before it
+reads or loads the addon, requires an ordinary non-symbolic-link receipt and
+artifact path, requires its non-following size to agree with the receipt before
+reading it, recomputes the artifact length and SHA-256, and loads only the
+package-relative final addon. Genuine addon loads occur in bounded children
+that exit before clean. The addon still cannot classify its own binary before
+it has been loaded, and JavaScript `lstat` cannot prove absence of every generic
+Windows reparse category.
 
-**Explicit nonclaim:** No production loader or production runtime behavior is
-implemented by this documentation-only contract.
+**Explicit nonclaim:** The private loader is not imported by the production
+entry point and implements no production traversal behavior.
 
 **Explicit nonclaim:** Receipt hashing and package-relative resolution do not
 defend against an attacker who can replace both the binary and receipt.
@@ -2390,18 +2423,18 @@ qualification is authorized by this contract.
 
 ## 69. Packaging and distribution
 
-**Selected future contract:** Generated `.node`, receipt, lock, and staging
-state remain ignored and uncommitted. No prebuilt binary, install-time
+**Currently implemented boundary:** Generated `.node`, receipt, lock, and
+staging state remain ignored and uncommitted. No prebuilt binary, install-time
 downloader, npm lifecycle build, `npm pack`, npm publication, release asset, or
 binary distribution is approved. Source-build distribution policy remains a
 later release decision. The first implementation is repository-development
 only on the exact qualified host.
 
-**Currently implemented characterization:** `build/Release` is ignored and
-absent. No generated output is tracked or present. The package remains
-`moxley-db@3.1.1`, Apache-2.0, with only `flatted` as a dependency and no
-package export map or engine declaration. No new npm publication decision has
-been made.
+**Currently implemented boundary:** `build/Release` is ignored and generated
+output is absent after the explicit lifecycle and tests. No generated output
+is tracked. The package remains `moxley-db@3.1.1`, Apache-2.0, with only
+`flatted` as a dependency and no package export map or engine declaration. No
+new npm publication decision has been made.
 
 **Deferred implementation:** Any source-distribution policy, prebuild,
 signature, release asset, package-file allowlist, engine declaration, package
@@ -2413,13 +2446,9 @@ state.
 
 ## 70. Explicitly deferred implementation and integration
 
-**Deferred implementation:** This documentation-only slice defers:
+**Deferred implementation:** The completed build/clean and private-loader
+slices still defer:
 
-- production C source promotion and removal of the old test-only source;
-- build and clean drivers;
-- loader code and loader tests;
-- manifest scripts;
-- `.gitignore` changes if any later prove necessary;
 - `index.js` changes or public exports;
 - traversal integration;
 - persisted-format loading;
@@ -2435,25 +2464,27 @@ state.
 - migration; and
 - npm publication.
 
-**Explicit nonclaim:** A selected future build/loader contract does not select
+**Explicit nonclaim:** The implemented build/loader boundaries do not select
 the complete accepted persisted schema, collection or executable-content
 policy, public open/create API, traversal error mapping, database locking,
 write protocol, recovery, durability, migration, adapter behavior, or Thoth
 behavior.
 
-## 71. Documentation-only delta and continuing qualification no-go
+## 71. Implemented private-loader delta and continuing qualification no-go
 
-**Currently implemented characterization:** This contract changes only
-`STATE_COMPATIBILITY.md`. It adds no test, production source, native source,
-manifest, lockfile, dependency, package version, fixture, binary, build output,
-or generated receipt. The authoritative baseline remains 50 tests, 11
-JavaScript/CJS/MJS files, one test-only C file, 19 persisted fixtures, three
-Markdown files, and two manifests.
+**Currently implemented boundary:** This private-loader slice changes exactly
+`package.json`, `STATE_COMPATIBILITY.md`,
+`lib/internal/windows-reparse-classifier.cjs`, and
+`test/windows-reparse-loader.test.cjs`. It adds exactly 14 top-level tests and
+brings the repository to 74 tests, 16 JavaScript/CJS/MJS files, one production
+C file, 19 byte-identical persisted fixtures, three Markdown files, and two
+manifests. It changes no dependency, lockfile, package version, license,
+production entry point, existing test file, native source, build/clean driver,
+fixture, or committed generated output.
 
-**Selected future contract:** Policy, current characterization evidence,
-deferred implementation, and nonclaims remain separate. A future implementer
-must satisfy every selected gate without citing this documentation as current
-enforcement.
+**Currently implemented boundary:** Policy, current characterization evidence,
+implemented enforcement, deferred integration, and nonclaims remain separate.
+The isolated loader tests do not qualify traversal or persisted-state loading.
 
 **Explicit nonclaim:** Complete Windows version-1 qualification remains
 **no-go**. This document does not claim TOCTOU resistance, hostile-local-user
@@ -2464,20 +2495,16 @@ runtime support.
 ## 72. Next independently testable boundary
 
 **Deferred implementation:** The next slice requires separate authorization
-and is limited to production-source promotion, the explicit build and clean
-drivers, the private loader, and their isolated tests. It must compile the one
-production source from the characterization tests and remove the old test-only
-C copy in the same slice.
+and is limited to a traversal-specific contract and characterization for exact
+native-result mapping and handle-relative safety. It must not be inferred from
+the private loader's valid `ordinary`, `reparse`, or `capability-gap` results.
 
-**Selected future contract:** That slice must still exclude `index.js`, public
-exports, production traversal integration, persisted-state loading, adapter
-behavior, and Thoth consumption. It must preserve explicit operator-only
-building, collision failure, exclusive locking, contained staging,
-no-replace promotion, canonical receipts, bounded clean behavior, one-shot
-loader caching, exact per-call native result validation, result poisoning,
-exact private errors, ignored generated output, and the continuing
-qualification no-go.
+**Selected future contract:** That later slice must define and isolate
+component-by-component traversal mapping, root and descendant handle-relative
+safety, error precedence, and the remaining TOCTOU boundary before any runtime
+integration is considered.
 
-**Explicit nonclaim:** Completion of that isolated implementation slice would
-not by itself authorize traversal, persisted-format acceptance, distribution,
-release, npm publication, or complete version-1 qualification.
+**Explicit nonclaim:** Completion of the build/clean and private-loader slices
+does not authorize `index.js` integration, persisted-format acceptance,
+adapter or Thoth behavior, distribution, release, npm publication, or complete
+version-1 qualification. The next boundary is not implemented here.

--- a/lib/internal/windows-reparse-classifier.cjs
+++ b/lib/internal/windows-reparse-classifier.cjs
@@ -1,0 +1,463 @@
+'use strict';
+
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { TextDecoder, types } = require('node:util');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..', '..');
+const RECEIPT_RELATIVE =
+  'build/Release/moxley-windows-reparse.receipt.json';
+const ARTIFACT_RELATIVE =
+  'build/Release/moxley-windows-reparse.node';
+const RECEIPT_PATH = path.join(PACKAGE_ROOT, ...RECEIPT_RELATIVE.split('/'));
+const ARTIFACT_PATH = path.join(PACKAGE_ROOT, ...ARTIFACT_RELATIVE.split('/'));
+const SOURCE_RELATIVE = 'native/windows-reparse-classifier.c';
+const MAX_RECEIPT_BYTES = 16 * 1024;
+const UINT32_MAX = 0xffffffff;
+const FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400;
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+const RECEIPT_KEYS = Object.freeze([
+  'receiptFormat',
+  'receiptVersion',
+  'nativeContractVersion',
+  'target',
+  'source',
+  'toolchain',
+  'artifact',
+]);
+const RESULT_KEYS = Object.freeze([
+  'outcome',
+  'fileAttributes',
+  'reparseTag',
+  'win32Error',
+  'closeWin32Error',
+]);
+
+const ERROR_DETAILS = Object.freeze({
+  MOXLEY_NATIVE_PLATFORM_UNSUPPORTED:
+    'Native classifier is unsupported on this platform.',
+  MOXLEY_NATIVE_ARTIFACT_MISSING:
+    'Native classifier artifact is missing.',
+  MOXLEY_NATIVE_RECEIPT_INVALID:
+    'Native classifier receipt is invalid.',
+  MOXLEY_NATIVE_INTEGRITY_MISMATCH:
+    'Native classifier artifact integrity check failed.',
+  MOXLEY_NATIVE_LOAD_FAILED:
+    'Native classifier failed to load.',
+  MOXLEY_NATIVE_EXPORT_INVALID:
+    'Native classifier export is invalid.',
+  MOXLEY_NATIVE_RESULT_INVALID:
+    'Native classifier returned invalid result evidence.',
+});
+
+class MoxleyNativeCapabilityError extends Error {
+  constructor(code, cause) {
+    if (cause === undefined) {
+      super(ERROR_DETAILS[code]);
+    } else {
+      super(ERROR_DETAILS[code], { cause });
+    }
+    this.name = 'MoxleyNativeCapabilityError';
+    this.code = code;
+  }
+}
+
+function capabilityError(code, cause) {
+  return new MoxleyNativeCapabilityError(code, cause);
+}
+
+function exactKeys(value, keys) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value)) === JSON.stringify(keys)
+  );
+}
+
+function positiveSafeInteger(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function validSha256(value) {
+  return typeof value === 'string' && HEX_64.test(value);
+}
+
+function readReceiptBytes() {
+  let metadata;
+  try {
+    metadata = fs.lstatSync(RECEIPT_PATH);
+  } catch (error) {
+    if (error !== null && error.code === 'ENOENT') {
+      throw capabilityError('MOXLEY_NATIVE_ARTIFACT_MISSING', error);
+    }
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID', error);
+  }
+
+  if (
+    !metadata.isFile() ||
+    metadata.isSymbolicLink() ||
+    !positiveSafeInteger(metadata.size) ||
+    metadata.size > MAX_RECEIPT_BYTES
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID');
+  }
+
+  let bytes;
+  try {
+    bytes = fs.readFileSync(RECEIPT_PATH);
+  } catch (error) {
+    if (error !== null && error.code === 'ENOENT') {
+      throw capabilityError('MOXLEY_NATIVE_ARTIFACT_MISSING', error);
+    }
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID', error);
+  }
+
+  if (bytes.length !== metadata.size) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID');
+  }
+  return bytes;
+}
+
+function decodeReceipt(bytes) {
+  if (
+    bytes.length === 0 ||
+    bytes.length > MAX_RECEIPT_BYTES ||
+    (bytes.length >= 3 &&
+      bytes[0] === 0xef &&
+      bytes[1] === 0xbb &&
+      bytes[2] === 0xbf)
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID');
+  }
+
+  let text;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch (error) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID', error);
+  }
+
+  if (
+    !text.endsWith('\n') ||
+    text.slice(0, -1).includes('\n') ||
+    text.includes('\r')
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID');
+  }
+
+  let receipt;
+  try {
+    receipt = JSON.parse(text.slice(0, -1));
+  } catch (error) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID', error);
+  }
+
+  validateReceipt(receipt);
+  if (!Buffer.from(`${JSON.stringify(receipt)}\n`, 'utf8').equals(bytes)) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID');
+  }
+  return receipt;
+}
+
+function validateReceipt(receipt) {
+  const runningNodeApi = Number(process.versions.napi);
+  if (
+    !exactKeys(receipt, RECEIPT_KEYS) ||
+    receipt.receiptFormat !== 'moxley-native-build-receipt' ||
+    receipt.receiptVersion !== 1 ||
+    receipt.nativeContractVersion !== 1 ||
+    !exactKeys(receipt.target, [
+      'platform',
+      'architecture',
+      'nodeVersion',
+      'nodeApiVersion',
+    ]) ||
+    receipt.target.platform !== 'win32' ||
+    receipt.target.architecture !== 'x64' ||
+    receipt.target.nodeVersion !== 'v24.13.0' ||
+    receipt.target.nodeVersion !== process.version ||
+    receipt.target.nodeApiVersion !== 8 ||
+    !Number.isSafeInteger(runningNodeApi) ||
+    runningNodeApi < 8 ||
+    !exactKeys(receipt.source, ['path', 'byteLength', 'sha256']) ||
+    receipt.source.path !== SOURCE_RELATIVE ||
+    !positiveSafeInteger(receipt.source.byteLength) ||
+    !validSha256(receipt.source.sha256) ||
+    !exactKeys(receipt.toolchain, [
+      'msvcVersion',
+      'compilerVersion',
+      'linkerVersion',
+      'windowsSdkVersion',
+      'nodeHeadersTreeSha256',
+      'nodeImportLibraryByteLength',
+      'nodeImportLibrarySha256',
+      'kernel32ImportLibraryByteLength',
+      'kernel32ImportLibrarySha256',
+    ]) ||
+    receipt.toolchain.msvcVersion !== '14.44.35207' ||
+    receipt.toolchain.compilerVersion !== '19.44.35228.0' ||
+    receipt.toolchain.linkerVersion !== '14.44.35228.0' ||
+    receipt.toolchain.windowsSdkVersion !== '10.0.26100.0' ||
+    !validSha256(receipt.toolchain.nodeHeadersTreeSha256) ||
+    receipt.toolchain.nodeImportLibraryByteLength !== 2_869_366 ||
+    receipt.toolchain.nodeImportLibrarySha256 !==
+      'be205f2934c17fbd56ce6cdfcfbeb2f6a85061d5141e7a58eba240a8477a12fd' ||
+    receipt.toolchain.kernel32ImportLibraryByteLength !== 311_908 ||
+    receipt.toolchain.kernel32ImportLibrarySha256 !==
+      '341c7d56125a03b458e4d5093e4c79b33123ccfdfd610fe236937b8e6f3134bb' ||
+    !exactKeys(receipt.artifact, ['path', 'byteLength', 'sha256']) ||
+    receipt.artifact.path !== ARTIFACT_RELATIVE ||
+    !positiveSafeInteger(receipt.artifact.byteLength) ||
+    !validSha256(receipt.artifact.sha256)
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_RECEIPT_INVALID');
+  }
+}
+
+function authenticateArtifact(receipt) {
+  let metadata;
+  try {
+    metadata = fs.lstatSync(ARTIFACT_PATH);
+  } catch (error) {
+    if (error !== null && error.code === 'ENOENT') {
+      throw capabilityError('MOXLEY_NATIVE_ARTIFACT_MISSING', error);
+    }
+    throw capabilityError('MOXLEY_NATIVE_INTEGRITY_MISMATCH', error);
+  }
+
+  if (
+    !metadata.isFile() ||
+    metadata.isSymbolicLink() ||
+    !positiveSafeInteger(metadata.size) ||
+    metadata.size !== receipt.artifact.byteLength
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_INTEGRITY_MISMATCH');
+  }
+
+  let bytes;
+  try {
+    bytes = fs.readFileSync(ARTIFACT_PATH);
+  } catch (error) {
+    if (error !== null && error.code === 'ENOENT') {
+      throw capabilityError('MOXLEY_NATIVE_ARTIFACT_MISSING', error);
+    }
+    throw capabilityError('MOXLEY_NATIVE_INTEGRITY_MISMATCH', error);
+  }
+
+  let digest;
+  try {
+    digest = createHash('sha256').update(bytes).digest('hex');
+  } catch (error) {
+    throw capabilityError('MOXLEY_NATIVE_INTEGRITY_MISMATCH', error);
+  }
+
+  if (
+    bytes.length !== metadata.size ||
+    digest !== receipt.artifact.sha256
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_INTEGRITY_MISMATCH');
+  }
+}
+
+function loadAddon() {
+  let addon;
+  try {
+    addon = require(ARTIFACT_PATH);
+  } catch (error) {
+    throw capabilityError('MOXLEY_NATIVE_LOAD_FAILED', error);
+  }
+
+  let keys;
+  let descriptor;
+  try {
+    if (
+      addon === null ||
+      typeof addon !== 'object' ||
+      types.isProxy(addon) ||
+      Array.isArray(addon)
+    ) {
+      throw capabilityError('MOXLEY_NATIVE_EXPORT_INVALID');
+    }
+    keys = Reflect.ownKeys(addon);
+    if (keys.length !== 1 || keys[0] !== 'classify') {
+      throw capabilityError('MOXLEY_NATIVE_EXPORT_INVALID');
+    }
+    descriptor = Reflect.getOwnPropertyDescriptor(addon, 'classify');
+  } catch (error) {
+    if (error instanceof MoxleyNativeCapabilityError) {
+      throw error;
+    }
+    throw capabilityError('MOXLEY_NATIVE_EXPORT_INVALID', error);
+  }
+
+  if (
+    descriptor === undefined ||
+    !Object.hasOwn(descriptor, 'value') ||
+    typeof descriptor.value !== 'function'
+  ) {
+    throw capabilityError('MOXLEY_NATIVE_EXPORT_INVALID');
+  }
+  return descriptor.value;
+}
+
+function resultError(reason) {
+  return capabilityError(
+    'MOXLEY_NATIVE_RESULT_INVALID',
+    new TypeError(reason),
+  );
+}
+
+function inspectResult(result) {
+  if (
+    result === null ||
+    typeof result !== 'object' ||
+    types.isProxy(result) ||
+    Array.isArray(result)
+  ) {
+    return { reason: 'RESULT_NOT_OBJECT' };
+  }
+
+  let prototype;
+  let keys;
+  const descriptors = [];
+  try {
+    prototype = Object.getPrototypeOf(result);
+    keys = Reflect.ownKeys(result);
+    for (const key of RESULT_KEYS) {
+      descriptors.push(Reflect.getOwnPropertyDescriptor(result, key));
+    }
+  } catch {
+    return { reason: 'RESULT_INSPECTION_FAILED' };
+  }
+
+  if (prototype !== Object.prototype) {
+    return { reason: 'RESULT_NOT_OBJECT' };
+  }
+  if (
+    keys.length !== RESULT_KEYS.length ||
+    keys.some((key, index) => key !== RESULT_KEYS[index])
+  ) {
+    return { reason: 'RESULT_KEY_SET_INVALID' };
+  }
+
+  const values = [];
+  for (const descriptor of descriptors) {
+    if (
+      descriptor === undefined ||
+      descriptor.enumerable !== true ||
+      !Object.hasOwn(descriptor, 'value')
+    ) {
+      return { reason: 'RESULT_DESCRIPTOR_INVALID' };
+    }
+    values.push(descriptor.value);
+  }
+
+  const [outcome, fileAttributes, reparseTag, win32Error, closeWin32Error] =
+    values;
+  if (
+    !['ordinary', 'reparse', 'capability-gap'].includes(outcome) ||
+    ![fileAttributes, reparseTag, win32Error, closeWin32Error].every(
+      (value) =>
+        typeof value === 'number' &&
+        Number.isFinite(value) &&
+        Number.isInteger(value) &&
+        value >= 0 &&
+        value <= UINT32_MAX,
+    )
+  ) {
+    return { reason: 'RESULT_FIELD_INVALID' };
+  }
+
+  const hasReparseAttribute =
+    (fileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) !== 0;
+  const consistent =
+    (outcome === 'ordinary' &&
+      !hasReparseAttribute &&
+      reparseTag === 0 &&
+      win32Error === 0 &&
+      closeWin32Error === 0) ||
+    (outcome === 'reparse' &&
+      hasReparseAttribute &&
+      win32Error === 0 &&
+      closeWin32Error === 0) ||
+    (outcome === 'capability-gap' &&
+      (win32Error !== 0 || closeWin32Error !== 0));
+  if (!consistent) {
+    return { reason: 'RESULT_OUTCOME_INCONSISTENT' };
+  }
+
+  return {
+    accepted: Object.freeze({
+      outcome,
+      fileAttributes,
+      reparseTag,
+      win32Error,
+      closeWin32Error,
+    }),
+  };
+}
+
+function createWrapper(nativeClassify) {
+  let poisonReason = null;
+
+  function classify(target) {
+    if (poisonReason !== null) {
+      throw resultError(poisonReason);
+    }
+
+    let nativeResult;
+    try {
+      nativeResult = nativeClassify(target);
+    } catch {
+      poisonReason = 'RESULT_INSPECTION_FAILED';
+      throw resultError(poisonReason);
+    }
+
+    const disposition = inspectResult(nativeResult);
+    nativeResult = null;
+    if (disposition.reason !== undefined) {
+      poisonReason = disposition.reason;
+      throw resultError(poisonReason);
+    }
+    return disposition.accepted;
+  }
+
+  return Object.freeze({ classify });
+}
+
+let loadDisposition = 'unattempted';
+let cachedWrapper;
+let cachedFailure;
+
+function loadWindowsReparseClassifier() {
+  if (loadDisposition === 'loaded') {
+    return cachedWrapper;
+  }
+  if (loadDisposition === 'failed') {
+    throw cachedFailure;
+  }
+
+  try {
+    if (process.platform !== 'win32' || process.arch !== 'x64') {
+      throw capabilityError('MOXLEY_NATIVE_PLATFORM_UNSUPPORTED');
+    }
+    const receipt = decodeReceipt(readReceiptBytes());
+    authenticateArtifact(receipt);
+    const nativeClassify = loadAddon();
+    cachedWrapper = createWrapper(nativeClassify);
+    loadDisposition = 'loaded';
+    return cachedWrapper;
+  } catch (error) {
+    cachedFailure =
+      error instanceof MoxleyNativeCapabilityError
+        ? error
+        : capabilityError('MOXLEY_NATIVE_LOAD_FAILED', error);
+    loadDisposition = 'failed';
+    throw cachedFailure;
+  }
+}
+
+module.exports = Object.freeze({ loadWindowsReparseClassifier });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible class based database system for complicated schemas",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs test/restart-load-create.test.cjs test/child-state-preimage.test.cjs test/filesystem-capabilities.test.cjs test/windows-reparse-native.test.cjs test/windows-native-build.test.cjs",
+    "test": "node --test --test-concurrency=1 test/load-readiness.test.cjs test/repeated-load-mutation.test.cjs test/duplicate-create.test.cjs test/restart-load-create.test.cjs test/child-state-preimage.test.cjs test/filesystem-capabilities.test.cjs test/windows-reparse-native.test.cjs test/windows-native-build.test.cjs test/windows-reparse-loader.test.cjs",
     "build:native:windows": "node scripts/build-windows-native.cjs",
     "clean:native:windows": "node scripts/clean-windows-native.cjs"
   },

--- a/test/windows-reparse-loader.test.cjs
+++ b/test/windows-reparse-loader.test.cjs
@@ -1,0 +1,1222 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const Module = require('node:module');
+const os = require('node:os');
+const path = require('node:path');
+
+const WORKER_ARGUMENT = '--moxley-native-loader-worker';
+const IS_WORKER = process.argv[2] === WORKER_ARGUMENT;
+const REPOSITORY_ROOT = path.resolve(__dirname, '..');
+const LOADER = path.join(
+  REPOSITORY_ROOT,
+  'lib',
+  'internal',
+  'windows-reparse-classifier.cjs',
+);
+const BUILD_SCRIPT = path.join(
+  REPOSITORY_ROOT,
+  'scripts',
+  'build-windows-native.cjs',
+);
+const CLEAN_SCRIPT = path.join(
+  REPOSITORY_ROOT,
+  'scripts',
+  'clean-windows-native.cjs',
+);
+const RELEASE = path.join(REPOSITORY_ROOT, 'build', 'Release');
+const ARTIFACT = path.join(
+  RELEASE,
+  'moxley-windows-reparse.node',
+);
+const RECEIPT = path.join(
+  RELEASE,
+  'moxley-windows-reparse.receipt.json',
+);
+const LOCK = path.join(
+  RELEASE,
+  '.moxley-windows-reparse-build.lock',
+);
+const STAGING_PREFIX = '.moxley-windows-reparse-stage-';
+const REFERENCE_PREFIX = 'moxley-native-loader-test-';
+const REFERENCE_ARTIFACT = 'qualified-moxley-windows-reparse.node';
+const REFERENCE_RECEIPT = 'qualified-moxley-windows-reparse.receipt.json';
+const REFERENCE_PROBE = 'ordinary-probe.txt';
+const MAX_IO_BYTES = 1024 * 1024;
+const PROCESS_TIMEOUT_MS = 120_000;
+
+function canonicalJson(value) {
+  return `${JSON.stringify(value)}\n`;
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function exists(target) {
+  try {
+    await fsp.lstat(target);
+    return true;
+  } catch (error) {
+    if (error !== null && error.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function ordinaryResult() {
+  return {
+    outcome: 'ordinary',
+    fileAttributes: 0x20,
+    reparseTag: 0,
+    win32Error: 0,
+    closeWin32Error: 0,
+  };
+}
+
+function resultForVariant(variant, state) {
+  if (variant === 'null') return null;
+  if (variant === 'array') return [];
+  if (variant === 'proxy') return new Proxy(ordinaryResult(), {});
+  if (variant === 'null-prototype') {
+    return Object.assign(Object.create(null), ordinaryResult());
+  }
+  if (variant === 'missing-key') {
+    const result = ordinaryResult();
+    delete result.closeWin32Error;
+    return result;
+  }
+  if (variant === 'extra-key') {
+    return { ...ordinaryResult(), extra: 0 };
+  }
+  if (variant === 'reordered-keys') {
+    const result = {};
+    result.fileAttributes = 0x20;
+    result.outcome = 'ordinary';
+    result.reparseTag = 0;
+    result.win32Error = 0;
+    result.closeWin32Error = 0;
+    return result;
+  }
+  if (variant === 'symbol-key') {
+    const result = ordinaryResult();
+    result[Symbol('unexpected')] = 0;
+    return result;
+  }
+  if (variant === 'accessor') {
+    const result = {};
+    Object.defineProperty(result, 'outcome', {
+      enumerable: true,
+      get() {
+        throw new Error('ACCESSOR_MUST_NOT_RUN');
+      },
+    });
+    Object.assign(result, {
+      fileAttributes: 0x20,
+      reparseTag: 0,
+      win32Error: 0,
+      closeWin32Error: 0,
+    });
+    return result;
+  }
+  if (variant === 'non-enumerable') {
+    const result = {};
+    Object.defineProperty(result, 'outcome', {
+      value: 'ordinary',
+      enumerable: false,
+    });
+    Object.assign(result, {
+      fileAttributes: 0x20,
+      reparseTag: 0,
+      win32Error: 0,
+      closeWin32Error: 0,
+    });
+    return result;
+  }
+  if (variant === 'bad-outcome') {
+    return { ...ordinaryResult(), outcome: 'accepted' };
+  }
+  if (variant === 'numeric-string') {
+    return { ...ordinaryResult(), fileAttributes: '32' };
+  }
+  if (variant === 'nan') {
+    return { ...ordinaryResult(), reparseTag: Number.NaN };
+  }
+  if (variant === 'fraction') {
+    return { ...ordinaryResult(), win32Error: 0.5 };
+  }
+  if (variant === 'negative') {
+    return { ...ordinaryResult(), closeWin32Error: -1 };
+  }
+  if (variant === 'too-large') {
+    return { ...ordinaryResult(), fileAttributes: 0x1_0000_0000 };
+  }
+  if (variant === 'ordinary-reparse-attribute') {
+    return { ...ordinaryResult(), fileAttributes: 0x400 };
+  }
+  if (variant === 'ordinary-tag') {
+    return { ...ordinaryResult(), reparseTag: 1 };
+  }
+  if (variant === 'ordinary-error') {
+    return { ...ordinaryResult(), win32Error: 5 };
+  }
+  if (variant === 'reparse-no-attribute') {
+    return { ...ordinaryResult(), outcome: 'reparse' };
+  }
+  if (variant === 'reparse-error') {
+    return {
+      ...ordinaryResult(),
+      outcome: 'reparse',
+      fileAttributes: 0x400,
+      closeWin32Error: 6,
+    };
+  }
+  if (variant === 'capability-without-error') {
+    return { ...ordinaryResult(), outcome: 'capability-gap' };
+  }
+  if (variant === 'poison') {
+    return state.calls === 1 ? null : ordinaryResult();
+  }
+  return ordinaryResult();
+}
+
+function addonForVariant(variant, state) {
+  if (variant === 'export-empty') return {};
+  if (variant === 'export-extra') {
+    return { classify() {}, extra() {} };
+  }
+  if (variant === 'export-nonfunction') return { classify: 1 };
+  if (variant === 'export-array') {
+    const addon = [];
+    addon.classify = () => ordinaryResult();
+    return addon;
+  }
+  if (variant === 'export-accessor') {
+    const addon = {};
+    Object.defineProperty(addon, 'classify', {
+      enumerable: true,
+      get() {
+        throw new Error('EXPORT_ACCESSOR_MUST_NOT_RUN');
+      },
+    });
+    return addon;
+  }
+
+  return {
+    classify(target) {
+      state.calls += 1;
+      if (variant === 'native-throws') {
+        throw new RangeError('UNBOUNDED_NATIVE_THROW');
+      }
+      if (variant === 'copy-results') {
+        const nativeResult =
+          target === 'ordinary'
+            ? ordinaryResult()
+            : target === 'reparse'
+              ? {
+                  outcome: 'reparse',
+                  fileAttributes: 0x420,
+                  reparseTag: 0,
+                  win32Error: 0,
+                  closeWin32Error: 0,
+                }
+              : {
+                  outcome: 'capability-gap',
+                  fileAttributes: 0,
+                  reparseTag: 0x1234,
+                  win32Error: 13,
+                  closeWin32Error: 0,
+                };
+        state.nativeResults.push(nativeResult);
+        return nativeResult;
+      }
+      const result = resultForVariant(variant, state);
+      state.lastResult = result;
+      return result;
+    },
+  };
+}
+
+function summarizeError(error) {
+  return {
+    name: error.name,
+    code: error.code,
+    message: error.message,
+    causePresent: error.cause !== undefined,
+    causeName: error.cause === undefined ? null : error.cause.name,
+    causeCode:
+      error.cause === undefined || typeof error.cause.code !== 'string'
+        ? null
+        : error.cause.code,
+    causeMessage:
+      error.cause === undefined ||
+      !/^(?:RESULT_[A-Z_]+|SYNTHETIC_NATIVE_LOAD_FAILURE)$/.test(
+        error.cause.message,
+      )
+        ? null
+        : error.cause.message,
+  };
+}
+
+function captureFailure(operation) {
+  try {
+    operation();
+  } catch (error) {
+    assert.equal(error.name, 'MoxleyNativeCapabilityError');
+    assert.doesNotMatch(error.message, /[A-Za-z]:\\/);
+    assert.doesNotMatch(error.message, /[\r\n]/);
+    return error;
+  }
+  assert.fail('operation unexpectedly succeeded');
+}
+
+async function replaceWithReference(referenceRoot, sourceName, target) {
+  await fsp.rm(target, { force: true });
+  await fsp.copyFile(
+    path.join(referenceRoot, sourceName),
+    target,
+    fs.constants.COPYFILE_EXCL,
+  );
+}
+
+async function restoreGeneratedPair(referenceRoot) {
+  await fsp.mkdir(RELEASE, { recursive: true });
+  await replaceWithReference(referenceRoot, REFERENCE_ARTIFACT, ARTIFACT);
+  await replaceWithReference(referenceRoot, REFERENCE_RECEIPT, RECEIPT);
+}
+
+function installInstrumentation(request, state) {
+  const counters = {
+    receiptReads: 0,
+    artifactReads: 0,
+    hashes: 0,
+    requireCalls: 0,
+  };
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = function instrumentedReadFileSync(target, ...arguments_) {
+    const resolved = typeof target === 'string' ? path.resolve(target) : '';
+    if (resolved === RECEIPT) counters.receiptReads += 1;
+    if (resolved === ARTIFACT) counters.artifactReads += 1;
+    return originalReadFileSync.call(this, target, ...arguments_);
+  };
+
+  const crypto = require('node:crypto');
+  const originalCreateHash = crypto.createHash;
+  crypto.createHash = function instrumentedCreateHash(algorithm, ...arguments_) {
+    if (algorithm === 'sha256') counters.hashes += 1;
+    return originalCreateHash.call(this, algorithm, ...arguments_);
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function instrumentedLoad(moduleRequest, parent, isMain) {
+    if (
+      typeof moduleRequest === 'string' &&
+      path.resolve(moduleRequest) === ARTIFACT
+    ) {
+      counters.requireCalls += 1;
+      if (request.scenario === 'load-failure') {
+        const error = new Error('SYNTHETIC_NATIVE_LOAD_FAILURE');
+        error.code = 'SYNTHETIC_LOAD_CODE';
+        throw error;
+      }
+    }
+    return originalLoad.call(this, moduleRequest, parent, isMain);
+  };
+
+  if (
+    request.scenario !== 'real-valid' &&
+    request.scenario !== 'unsupported' &&
+    request.scenario !== 'terminal-load' &&
+    request.scenario !== 'load-failure'
+  ) {
+    require.cache[ARTIFACT] = {
+      id: ARTIFACT,
+      filename: ARTIFACT,
+      loaded: true,
+      exports: addonForVariant(request.variant, state),
+    };
+  }
+  return counters;
+}
+
+function assertOuter(error, code, message) {
+  assert.equal(error.code, code);
+  assert.equal(error.message, message);
+}
+
+async function runWorkerScenario(request) {
+  if (request.scenario === 'unsupported') {
+    Object.defineProperty(process, request.variant, {
+      configurable: true,
+      value: request.variant === 'platform' ? 'linux' : 'arm64',
+    });
+  }
+
+  const state = { calls: 0, lastResult: null, nativeResults: [] };
+  const counters = installInstrumentation(request, state);
+  const { loadWindowsReparseClassifier } = require(LOADER);
+
+  if (request.scenario === 'real-valid') {
+    const wrapper = loadWindowsReparseClassifier();
+    const result = wrapper.classify(
+      path.join(request.referenceRoot, REFERENCE_PROBE),
+    );
+    assert.deepEqual(Object.keys(wrapper), ['classify']);
+    assert.equal(Object.isFrozen(wrapper), true);
+    assert.equal(Object.isFrozen(result), true);
+    assert.deepEqual(result, ordinaryResult());
+    return { counters, result };
+  }
+
+  if (request.scenario === 'successful-cache') {
+    const first = loadWindowsReparseClassifier();
+    const second = loadWindowsReparseClassifier();
+    assert.equal(first, second);
+    assert.equal(Object.isFrozen(first), true);
+    assert.deepEqual(first.classify('ignored'), ordinaryResult());
+    return { counters, calls: state.calls, sameWrapper: first === second };
+  }
+
+  if (request.scenario === 'copy-results') {
+    const wrapper = loadWindowsReparseClassifier();
+    const accepted = ['ordinary', 'reparse', 'capability-gap'].map((value) =>
+      wrapper.classify(value),
+    );
+    assert.equal(state.calls, 3);
+    for (let index = 0; index < accepted.length; index += 1) {
+      assert.notEqual(accepted[index], state.nativeResults[index]);
+      assert.equal(Object.isFrozen(accepted[index]), true);
+      assert.equal(Object.isFrozen(state.nativeResults[index]), false);
+      assert.deepEqual(Object.keys(accepted[index]), [
+        'outcome',
+        'fileAttributes',
+        'reparseTag',
+        'win32Error',
+        'closeWin32Error',
+      ]);
+    }
+    return {
+      counters,
+      calls: state.calls,
+      outcomes: accepted.map((value) => value.outcome),
+    };
+  }
+
+  if (request.scenario === 'unsupported') {
+    const first = captureFailure(loadWindowsReparseClassifier);
+    const afterFirst = { ...counters };
+    const second = captureFailure(loadWindowsReparseClassifier);
+    assertOuter(
+      first,
+      'MOXLEY_NATIVE_PLATFORM_UNSUPPORTED',
+      'Native classifier is unsupported on this platform.',
+    );
+    assert.equal(first, second);
+    assert.deepEqual(counters, afterFirst);
+    return {
+      counters,
+      error: summarizeError(first),
+      sameError: first === second,
+    };
+  }
+
+  if (request.scenario === 'terminal-load') {
+    const first = captureFailure(loadWindowsReparseClassifier);
+    const afterFirst = { ...counters };
+    await restoreGeneratedPair(request.referenceRoot);
+    const second = captureFailure(loadWindowsReparseClassifier);
+    assert.equal(first, second);
+    assert.deepEqual(counters, afterFirst);
+    return {
+      counters,
+      error: summarizeError(first),
+      sameError: first === second,
+    };
+  }
+
+  if (request.scenario === 'load-failure') {
+    const first = captureFailure(loadWindowsReparseClassifier);
+    const afterFirst = { ...counters };
+    const second = captureFailure(loadWindowsReparseClassifier);
+    assertOuter(
+      first,
+      'MOXLEY_NATIVE_LOAD_FAILED',
+      'Native classifier failed to load.',
+    );
+    assert.equal(first, second);
+    assert.deepEqual(counters, afterFirst);
+    return {
+      counters,
+      error: summarizeError(first),
+      sameError: first === second,
+    };
+  }
+
+  if (request.scenario === 'export-invalid') {
+    const first = captureFailure(loadWindowsReparseClassifier);
+    const afterFirst = { ...counters };
+    require.cache[ARTIFACT].exports = addonForVariant('valid', state);
+    const second = captureFailure(loadWindowsReparseClassifier);
+    assertOuter(
+      first,
+      'MOXLEY_NATIVE_EXPORT_INVALID',
+      'Native classifier export is invalid.',
+    );
+    assert.equal(first, second);
+    assert.deepEqual(counters, afterFirst);
+    return {
+      counters,
+      error: summarizeError(first),
+      sameError: first === second,
+    };
+  }
+
+  const wrapper = loadWindowsReparseClassifier();
+  if (request.scenario === 'reflect-failure') {
+    const original =
+      request.variant === 'own-keys'
+        ? Reflect.ownKeys
+        : request.variant === 'descriptor'
+          ? Reflect.getOwnPropertyDescriptor
+          : Object.getPrototypeOf;
+    const replacement = function throwingInspection(target, ...arguments_) {
+      if (target === state.lastResult) {
+        throw new Error('UNBOUNDED_REFLECTION_THROW');
+      }
+      return original.call(this, target, ...arguments_);
+    };
+    if (request.variant === 'own-keys') Reflect.ownKeys = replacement;
+    else if (request.variant === 'descriptor') {
+      Reflect.getOwnPropertyDescriptor = replacement;
+    } else Object.getPrototypeOf = replacement;
+  }
+
+  if (request.scenario === 'poison') {
+    const first = captureFailure(() => wrapper.classify('first'));
+    const second = captureFailure(() => wrapper.classify('second'));
+    const third = captureFailure(() => wrapper.classify('third'));
+    assert.equal(state.calls, 1);
+    assert.notEqual(first.cause, second.cause);
+    assert.notEqual(second.cause, third.cause);
+    for (const error of [first, second, third]) {
+      assertOuter(
+        error,
+        'MOXLEY_NATIVE_RESULT_INVALID',
+        'Native classifier returned invalid result evidence.',
+      );
+      assert.equal(error.cause.name, 'TypeError');
+      assert.equal(error.cause.message, 'RESULT_NOT_OBJECT');
+    }
+    return {
+      counters,
+      calls: state.calls,
+      errors: [first, second, third].map(summarizeError),
+    };
+  }
+
+  const error = captureFailure(() => wrapper.classify('case'));
+  assertOuter(
+    error,
+    'MOXLEY_NATIVE_RESULT_INVALID',
+    'Native classifier returned invalid result evidence.',
+  );
+  assert.equal(error.cause.name, 'TypeError');
+  return {
+    counters,
+    calls: state.calls,
+    error: summarizeError(error),
+  };
+}
+
+function readBoundedRequest() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let length = 0;
+    process.stdin.on('data', (chunk) => {
+      length += chunk.length;
+      if (length > MAX_IO_BYTES) {
+        reject(new Error('request too large'));
+        process.stdin.destroy();
+      } else {
+        chunks.push(chunk);
+      }
+    });
+    process.stdin.once('error', reject);
+    process.stdin.once('end', () => {
+      try {
+        const text = Buffer.concat(chunks).toString('utf8');
+        if (!text.endsWith('\n') || text.indexOf('\n') !== text.length - 1) {
+          throw new Error('request framing invalid');
+        }
+        const request = JSON.parse(text.slice(0, -1));
+        if (
+          canonicalJson(request) !== text ||
+          JSON.stringify(Object.keys(request)) !==
+            JSON.stringify([
+              'requestFormat',
+              'requestVersion',
+              'scenario',
+              'variant',
+              'referenceRoot',
+            ]) ||
+          request.requestFormat !== 'moxley-native-loader-test' ||
+          request.requestVersion !== 1 ||
+          typeof request.scenario !== 'string' ||
+          typeof request.variant !== 'string' ||
+          !(
+            request.referenceRoot === null ||
+            typeof request.referenceRoot === 'string'
+          )
+        ) {
+          throw new Error('request invalid');
+        }
+        resolve(request);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+async function workerMain() {
+  if (process.argv.length !== 3) throw new Error('worker arguments invalid');
+  const request = await readBoundedRequest();
+  const evidence = await runWorkerScenario(request);
+  process.stdout.write(canonicalJson({ status: 'ok', evidence }));
+}
+
+if (IS_WORKER) {
+  workerMain().catch(() => {
+    process.stderr.write('Native loader test worker failed.\n');
+    process.exitCode = 1;
+  });
+} else {
+  const { after, before, test } = require('node:test');
+  let referenceRoot = null;
+  let referenceEvidence = null;
+  let repositoryOutputMayExist = false;
+
+  function runProcess(file, arguments_, options = {}) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(file, arguments_, {
+        cwd: options.cwd,
+        env: process.env,
+        shell: false,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+      const stdout = [];
+      const stderr = [];
+      let stdoutLength = 0;
+      let stderrLength = 0;
+      const timeout = setTimeout(() => child.kill(), PROCESS_TIMEOUT_MS);
+      child.once('error', reject);
+      child.stdout.on('data', (chunk) => {
+        stdoutLength += chunk.length;
+        if (stdoutLength > MAX_IO_BYTES) child.kill();
+        else stdout.push(chunk);
+      });
+      child.stderr.on('data', (chunk) => {
+        stderrLength += chunk.length;
+        if (stderrLength > MAX_IO_BYTES) child.kill();
+        else stderr.push(chunk);
+      });
+      child.once('close', (code, signal) => {
+        clearTimeout(timeout);
+        if (stdoutLength > MAX_IO_BYTES || stderrLength > MAX_IO_BYTES) {
+          reject(new Error('bounded test subprocess output exceeded'));
+          return;
+        }
+        resolve({
+          code,
+          signal,
+          stdout: Buffer.concat(stdout),
+          stderr: Buffer.concat(stderr),
+        });
+      });
+      if (options.input === undefined) child.stdin.end();
+      else child.stdin.end(options.input);
+    });
+  }
+
+  function parseCanonicalOutput(bytes) {
+    const text = bytes.toString('utf8');
+    assert.equal(text.endsWith('\n'), true);
+    assert.equal(text.indexOf('\n'), text.length - 1);
+    assert.equal(text.includes('\r'), false);
+    const value = JSON.parse(text.slice(0, -1));
+    assert.equal(canonicalJson(value), text);
+    return value;
+  }
+
+  async function runNodeScript(script) {
+    return runProcess(process.execPath, [script], { cwd: os.tmpdir() });
+  }
+
+  async function runLoaderWorker(scenario, variant = '', root = referenceRoot) {
+    const request = {
+      requestFormat: 'moxley-native-loader-test',
+      requestVersion: 1,
+      scenario,
+      variant,
+      referenceRoot: root,
+    };
+    const result = await runProcess(
+      process.execPath,
+      [__filename, WORKER_ARGUMENT],
+      { cwd: root === null ? os.tmpdir() : root, input: canonicalJson(request) },
+    );
+    assert.equal(result.code, 0, result.stderr.toString('utf8'));
+    assert.equal(result.signal, null);
+    assert.equal(result.stderr.length, 0);
+    const response = parseCanonicalOutput(result.stdout);
+    assert.equal(response.status, 'ok');
+    return response.evidence;
+  }
+
+  async function releaseEntries() {
+    if (!(await exists(RELEASE))) return [];
+    return (await fsp.readdir(RELEASE)).sort();
+  }
+
+  async function assertGeneratedStateAbsent() {
+    for (const target of [ARTIFACT, RECEIPT, LOCK]) {
+      assert.equal(await exists(target), false, `${target} must be absent`);
+    }
+    const entries = await releaseEntries();
+    assert.deepEqual(
+      entries.filter((name) => name.startsWith(STAGING_PREFIX)),
+      [],
+    );
+    assert.deepEqual(
+      entries.filter((name) =>
+        /\.(?:node|obj|lib|exp|pdb|rsp)$/i.test(name),
+      ),
+      [],
+    );
+  }
+
+  async function authenticateReferenceRoot() {
+    assert.notEqual(referenceRoot, null);
+    const tempRoot = await fsp.realpath(os.tmpdir());
+    const canonicalRoot = await fsp.realpath(referenceRoot);
+    const metadata = await fsp.lstat(referenceRoot);
+    assert.equal(metadata.isDirectory(), true);
+    assert.equal(metadata.isSymbolicLink(), false);
+    assert.equal(path.dirname(canonicalRoot).toLowerCase(), tempRoot.toLowerCase());
+    assert.equal(path.basename(canonicalRoot).startsWith(REFERENCE_PREFIX), true);
+    const entries = (await fsp.readdir(canonicalRoot)).sort();
+    assert.deepEqual(entries, [
+      REFERENCE_PROBE,
+      REFERENCE_ARTIFACT,
+      REFERENCE_RECEIPT,
+    ].sort());
+    return canonicalRoot;
+  }
+
+  async function explicitClean() {
+    const result = await runNodeScript(CLEAN_SCRIPT);
+    assert.equal(result.code, 0, result.stderr.toString('utf8'));
+    assert.equal(result.signal, null);
+    assert.equal(result.stderr.length, 0);
+    const output = parseCanonicalOutput(result.stdout);
+    assert.equal(output.status, 'clean');
+    repositoryOutputMayExist = false;
+    await assertGeneratedStateAbsent();
+    return output;
+  }
+
+  async function installReferenceOutputs(options = {}) {
+    await assertGeneratedStateAbsent();
+    await fsp.mkdir(RELEASE, { recursive: true });
+    if (options.artifact !== false) {
+      if (options.artifactBytes === undefined) {
+        await fsp.copyFile(
+          path.join(referenceRoot, REFERENCE_ARTIFACT),
+          ARTIFACT,
+          fs.constants.COPYFILE_EXCL,
+        );
+      } else {
+        await fsp.writeFile(ARTIFACT, options.artifactBytes, { flag: 'wx' });
+      }
+    }
+    if (options.receipt !== false) {
+      if (options.receiptBytes === undefined) {
+        await fsp.copyFile(
+          path.join(referenceRoot, REFERENCE_RECEIPT),
+          RECEIPT,
+          fs.constants.COPYFILE_EXCL,
+        );
+      } else {
+        await fsp.writeFile(RECEIPT, options.receiptBytes, { flag: 'wx' });
+      }
+    }
+    repositoryOutputMayExist = true;
+  }
+
+  async function withReferenceOutputs(operation, options = {}) {
+    await installReferenceOutputs(options);
+    try {
+      return await operation();
+    } finally {
+      await explicitClean();
+    }
+  }
+
+  function assertTerminalEvidence(
+    evidence,
+    code,
+    message,
+    expectedCounters,
+  ) {
+    assert.equal(evidence.sameError, true);
+    assert.equal(evidence.error.name, 'MoxleyNativeCapabilityError');
+    assert.equal(evidence.error.code, code);
+    assert.equal(evidence.error.message, message);
+    assert.deepEqual(evidence.counters, expectedCounters);
+  }
+
+  before(async () => {
+    await assertGeneratedStateAbsent();
+    const build = await runNodeScript(BUILD_SCRIPT);
+    assert.equal(build.code, 0, build.stderr.toString('utf8'));
+    assert.equal(build.signal, null);
+    assert.equal(build.stderr.length, 0);
+    const buildOutput = parseCanonicalOutput(build.stdout);
+    assert.equal(buildOutput.status, 'built');
+    repositoryOutputMayExist = true;
+
+    referenceRoot = await fsp.mkdtemp(path.join(os.tmpdir(), REFERENCE_PREFIX));
+    await fsp.copyFile(
+      ARTIFACT,
+      path.join(referenceRoot, REFERENCE_ARTIFACT),
+      fs.constants.COPYFILE_EXCL,
+    );
+    await fsp.copyFile(
+      RECEIPT,
+      path.join(referenceRoot, REFERENCE_RECEIPT),
+      fs.constants.COPYFILE_EXCL,
+    );
+    await fsp.writeFile(
+      path.join(referenceRoot, REFERENCE_PROBE),
+      'ordinary\n',
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    await authenticateReferenceRoot();
+    const artifactBytes = await fsp.readFile(
+      path.join(referenceRoot, REFERENCE_ARTIFACT),
+    );
+    const receiptBytes = await fsp.readFile(
+      path.join(referenceRoot, REFERENCE_RECEIPT),
+    );
+    const receipt = JSON.parse(receiptBytes.toString('utf8'));
+    referenceEvidence = Object.freeze({
+      artifactByteLength: artifactBytes.length,
+      artifactSha256: sha256(artifactBytes),
+      receiptArtifactByteLength: receipt.artifact.byteLength,
+      receiptArtifactSha256: receipt.artifact.sha256,
+    });
+    assert.equal(
+      referenceEvidence.artifactByteLength,
+      referenceEvidence.receiptArtifactByteLength,
+    );
+    assert.equal(
+      referenceEvidence.artifactSha256,
+      referenceEvidence.receiptArtifactSha256,
+    );
+  });
+
+  after(async () => {
+    if (
+      repositoryOutputMayExist ||
+      (await exists(ARTIFACT)) ||
+      (await exists(RECEIPT)) ||
+      (await exists(LOCK))
+    ) {
+      await explicitClean();
+    }
+    await assertGeneratedStateAbsent();
+    if (referenceRoot !== null && (await exists(referenceRoot))) {
+      const canonicalRoot = await authenticateReferenceRoot();
+      await fsp.rm(canonicalRoot, { recursive: true, force: false });
+      assert.equal(await exists(canonicalRoot), false);
+    }
+  });
+
+  test('private loader exports only the synchronous one-shot loader', () => {
+    const surface = require(LOADER);
+    assert.deepEqual(Reflect.ownKeys(surface), [
+      'loadWindowsReparseClassifier',
+    ]);
+    assert.equal(Object.isFrozen(surface), true);
+    assert.equal(typeof surface.loadWindowsReparseClassifier, 'function');
+    assert.equal(surface.loadWindowsReparseClassifier.length, 0);
+    assert.notEqual(
+      surface.loadWindowsReparseClassifier.constructor.name,
+      'AsyncFunction',
+    );
+  });
+
+  test(
+    'valid load authenticates the canonical receipt and package-relative artifact',
+    async () => {
+      const evidence = await runLoaderWorker('real-valid');
+      assert.deepEqual(evidence.result, ordinaryResult());
+      assert.deepEqual(evidence.counters, {
+        receiptReads: 1,
+        artifactReads: 1,
+        hashes: 1,
+        requireCalls: 1,
+      });
+      assert.equal(
+        referenceEvidence.artifactSha256,
+        referenceEvidence.receiptArtifactSha256,
+      );
+      await explicitClean();
+    },
+  );
+
+  test(
+    'successful loading returns and reuses one frozen wrapper without reloading',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const evidence = await runLoaderWorker('successful-cache', 'valid');
+        assert.equal(evidence.sameWrapper, true);
+        assert.equal(evidence.calls, 1);
+        assert.deepEqual(evidence.counters, {
+          receiptReads: 1,
+          artifactReads: 1,
+          hashes: 1,
+          requireCalls: 1,
+        });
+      });
+    },
+  );
+
+  test(
+    'ordinary reparse and capability-gap evidence is copied frozen and invoked once',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const evidence = await runLoaderWorker('copy-results', 'copy-results');
+        assert.equal(evidence.calls, 3);
+        assert.deepEqual(evidence.outcomes, [
+          'ordinary',
+          'reparse',
+          'capability-gap',
+        ]);
+      });
+    },
+  );
+
+  test('unsupported platform or architecture fails terminally', async () => {
+    await assertGeneratedStateAbsent();
+    for (const variant of ['platform', 'arch']) {
+      const evidence = await runLoaderWorker('unsupported', variant, null);
+      assertTerminalEvidence(
+        evidence,
+        'MOXLEY_NATIVE_PLATFORM_UNSUPPORTED',
+        'Native classifier is unsupported on this platform.',
+        {
+          receiptReads: 0,
+          artifactReads: 0,
+          hashes: 0,
+          requireCalls: 0,
+        },
+      );
+    }
+  });
+
+  test('missing or incomplete generated output fails terminally', async () => {
+    const cases = [
+      { artifact: false, receipt: false, reads: 0 },
+      { artifact: true, receipt: false, reads: 0 },
+      { artifact: false, receipt: true, reads: 1 },
+    ];
+    for (const item of cases) {
+      await installReferenceOutputs(item);
+      try {
+        const evidence = await runLoaderWorker('terminal-load', 'missing');
+        assertTerminalEvidence(
+          evidence,
+          'MOXLEY_NATIVE_ARTIFACT_MISSING',
+          'Native classifier artifact is missing.',
+          {
+            receiptReads: item.reads,
+            artifactReads: 0,
+            hashes: 0,
+            requireCalls: 0,
+          },
+        );
+        assert.equal(evidence.error.causePresent, true);
+        assert.equal(evidence.error.causeCode, 'ENOENT');
+      } finally {
+        await explicitClean();
+      }
+    }
+  });
+
+  test(
+    'malformed noncanonical or incompatible receipts fail terminally',
+    async () => {
+      const referenceBytes = await fsp.readFile(
+        path.join(referenceRoot, REFERENCE_RECEIPT),
+      );
+      const reference = JSON.parse(referenceBytes.toString('utf8'));
+      const incompatibleNode = structuredClone(reference);
+      incompatibleNode.target.nodeVersion = 'v24.13.1';
+      const incompatibleApi = structuredClone(reference);
+      incompatibleApi.target.nodeApiVersion = 7;
+      const wrongSource = structuredClone(reference);
+      wrongSource.source.path = 'test/native/windows-reparse-classifier.c';
+      const wrongArtifact = structuredClone(reference);
+      wrongArtifact.artifact.path = 'build/Debug/other.node';
+      const extraKey = structuredClone(reference);
+      extraKey.extra = true;
+      const reordered = {
+        receiptVersion: reference.receiptVersion,
+        receiptFormat: reference.receiptFormat,
+        nativeContractVersion: reference.nativeContractVersion,
+        target: reference.target,
+        source: reference.source,
+        toolchain: reference.toolchain,
+        artifact: reference.artifact,
+      };
+      const text = referenceBytes.toString('utf8');
+      const duplicate = text.replace(
+        '{"receiptFormat":',
+        '{"receiptFormat":"duplicate","receiptFormat":',
+      );
+      const cases = [
+        Buffer.from([0xff, 0x0a]),
+        Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), referenceBytes]),
+        referenceBytes.subarray(0, referenceBytes.length - 1),
+        Buffer.concat([referenceBytes, Buffer.from('\n')]),
+        Buffer.from(`${JSON.stringify(reference, null, 2)}\n`),
+        Buffer.from(duplicate),
+        Buffer.from(canonicalJson(extraKey)),
+        Buffer.from(canonicalJson(reordered)),
+        Buffer.from(canonicalJson(incompatibleNode)),
+        Buffer.from(canonicalJson(incompatibleApi)),
+        Buffer.from(canonicalJson(wrongSource)),
+        Buffer.from(canonicalJson(wrongArtifact)),
+      ];
+      for (const receiptBytes of cases) {
+        await withReferenceOutputs(
+          async () => {
+            const evidence = await runLoaderWorker(
+              'terminal-load',
+              'receipt-invalid',
+            );
+            assertTerminalEvidence(
+              evidence,
+              'MOXLEY_NATIVE_RECEIPT_INVALID',
+              'Native classifier receipt is invalid.',
+              evidence.counters,
+            );
+            assert.equal(evidence.counters.hashes, 0);
+            assert.equal(evidence.counters.requireCalls, 0);
+          },
+          { receiptBytes },
+        );
+      }
+    },
+  );
+
+  test('artifact byte-length or digest mismatch fails terminally', async () => {
+    const referenceBytes = await fsp.readFile(
+      path.join(referenceRoot, REFERENCE_RECEIPT),
+    );
+    const reference = JSON.parse(referenceBytes.toString('utf8'));
+    const cases = [];
+    const badLength = structuredClone(reference);
+    badLength.artifact.byteLength += 1;
+    cases.push({
+      receiptBytes: Buffer.from(canonicalJson(badLength)),
+      counters: {
+        receiptReads: 1,
+        artifactReads: 0,
+        hashes: 0,
+        requireCalls: 0,
+      },
+    });
+    const badDigest = structuredClone(reference);
+    badDigest.artifact.sha256 = '0'.repeat(64);
+    cases.push({
+      receiptBytes: Buffer.from(canonicalJson(badDigest)),
+      counters: {
+        receiptReads: 1,
+        artifactReads: 1,
+        hashes: 1,
+        requireCalls: 0,
+      },
+    });
+    for (const item of cases) {
+      await withReferenceOutputs(
+        async () => {
+          const evidence = await runLoaderWorker(
+            'terminal-load',
+            'integrity-invalid',
+          );
+          assertTerminalEvidence(
+            evidence,
+            'MOXLEY_NATIVE_INTEGRITY_MISMATCH',
+            'Native classifier artifact integrity check failed.',
+            item.counters,
+          );
+        },
+        { receiptBytes: item.receiptBytes },
+      );
+    }
+  });
+
+  test(
+    'native addon load failure retains bounded causal evidence without retry',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const evidence = await runLoaderWorker('load-failure');
+        assertTerminalEvidence(
+          evidence,
+          'MOXLEY_NATIVE_LOAD_FAILED',
+          'Native classifier failed to load.',
+          {
+            receiptReads: 1,
+            artifactReads: 1,
+            hashes: 1,
+            requireCalls: 1,
+          },
+        );
+        assert.equal(evidence.error.causePresent, true);
+        assert.equal(evidence.error.causeName, 'Error');
+        assert.equal(evidence.error.causeCode, 'SYNTHETIC_LOAD_CODE');
+        assert.equal(
+          evidence.error.causeMessage,
+          'SYNTHETIC_NATIVE_LOAD_FAILURE',
+        );
+      });
+    },
+  );
+
+  test('invalid native export shape fails terminally', async () => {
+    await withReferenceOutputs(async () => {
+      for (const variant of [
+        'export-empty',
+        'export-extra',
+        'export-nonfunction',
+        'export-array',
+        'export-accessor',
+      ]) {
+        const evidence = await runLoaderWorker('export-invalid', variant);
+        assertTerminalEvidence(
+          evidence,
+          'MOXLEY_NATIVE_EXPORT_INVALID',
+          'Native classifier export is invalid.',
+          {
+            receiptReads: 1,
+            artifactReads: 1,
+            hashes: 1,
+            requireCalls: 1,
+          },
+        );
+      }
+    });
+  });
+
+  test(
+    'invalid result objects keys prototypes proxies and symbols use the closed reasons',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const cases = new Map([
+          ['null', 'RESULT_NOT_OBJECT'],
+          ['array', 'RESULT_NOT_OBJECT'],
+          ['proxy', 'RESULT_NOT_OBJECT'],
+          ['null-prototype', 'RESULT_NOT_OBJECT'],
+          ['missing-key', 'RESULT_KEY_SET_INVALID'],
+          ['extra-key', 'RESULT_KEY_SET_INVALID'],
+          ['reordered-keys', 'RESULT_KEY_SET_INVALID'],
+          ['symbol-key', 'RESULT_KEY_SET_INVALID'],
+        ]);
+        for (const [variant, reason] of cases) {
+          const evidence = await runLoaderWorker('invalid-result', variant);
+          assert.equal(evidence.calls, 1);
+          assert.equal(evidence.error.code, 'MOXLEY_NATIVE_RESULT_INVALID');
+          assert.equal(evidence.error.causeName, 'TypeError');
+          assert.equal(evidence.error.causeMessage, reason);
+        }
+      });
+    },
+  );
+
+  test(
+    'invalid descriptors fields and outcome combinations use the closed reasons',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const cases = new Map([
+          ['accessor', 'RESULT_DESCRIPTOR_INVALID'],
+          ['non-enumerable', 'RESULT_DESCRIPTOR_INVALID'],
+          ['bad-outcome', 'RESULT_FIELD_INVALID'],
+          ['numeric-string', 'RESULT_FIELD_INVALID'],
+          ['nan', 'RESULT_FIELD_INVALID'],
+          ['fraction', 'RESULT_FIELD_INVALID'],
+          ['negative', 'RESULT_FIELD_INVALID'],
+          ['too-large', 'RESULT_FIELD_INVALID'],
+          ['ordinary-reparse-attribute', 'RESULT_OUTCOME_INCONSISTENT'],
+          ['ordinary-tag', 'RESULT_OUTCOME_INCONSISTENT'],
+          ['ordinary-error', 'RESULT_OUTCOME_INCONSISTENT'],
+          ['reparse-no-attribute', 'RESULT_OUTCOME_INCONSISTENT'],
+          ['reparse-error', 'RESULT_OUTCOME_INCONSISTENT'],
+          ['capability-without-error', 'RESULT_OUTCOME_INCONSISTENT'],
+        ]);
+        for (const [variant, reason] of cases) {
+          const evidence = await runLoaderWorker('invalid-result', variant);
+          assert.equal(evidence.calls, 1);
+          assert.equal(evidence.error.causeName, 'TypeError');
+          assert.equal(evidence.error.causeMessage, reason);
+        }
+      });
+    },
+  );
+
+  test(
+    'native or reflective inspection failures become bounded result-invalid evidence',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const native = await runLoaderWorker('invalid-result', 'native-throws');
+        assert.equal(native.calls, 1);
+        assert.equal(native.error.causeName, 'TypeError');
+        assert.equal(native.error.causeMessage, 'RESULT_INSPECTION_FAILED');
+        for (const variant of ['prototype', 'own-keys', 'descriptor']) {
+          const reflected = await runLoaderWorker('reflect-failure', variant);
+          assert.equal(reflected.calls, 1);
+          assert.equal(reflected.error.causeName, 'TypeError');
+          assert.equal(
+            reflected.error.causeMessage,
+            'RESULT_INSPECTION_FAILED',
+          );
+        }
+      });
+    },
+  );
+
+  test(
+    'the first invalid result poisons the wrapper and prevents every later native call',
+    async () => {
+      await withReferenceOutputs(async () => {
+        const evidence = await runLoaderWorker('poison', 'poison');
+        assert.equal(evidence.calls, 1);
+        assert.equal(evidence.errors.length, 3);
+        for (const error of evidence.errors) {
+          assert.equal(error.code, 'MOXLEY_NATIVE_RESULT_INVALID');
+          assert.equal(
+            error.message,
+            'Native classifier returned invalid result evidence.',
+          );
+          assert.equal(error.causeName, 'TypeError');
+          assert.equal(error.causeMessage, 'RESULT_NOT_OBJECT');
+        }
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- add the private synchronous one-shot Windows reparse-classifier loader
- independently validate canonical receipt bytes, artifact integrity, native exports, and exact result evidence
- cache first load success or failure and permanently poison a classifier after invalid native result evidence
- add 14 isolated same-file worker tests and serialize the repository test command around shared generated paths
- reconcile the implemented boundary and continuing qualification no-go in `STATE_COMPATIBILITY.md`

## Verification

- `npm test` twice: 74/74 each, with zero failures, skips, todos, or cancellations
- `node --check`: 16/16 JavaScript/CJS/MJS files
- manifests: 2/2; persisted fixtures: 19/19 unchanged; Markdown files and exact-case local links: 3/3
- exact four-path scope; protected paths and package lock unchanged; generated and temporary output absent

## Non-goals

No `index.js` integration, public export, traversal behavior, persisted-state loading, adapter or Thoth behavior, dependency or version change, release, npm publication, fallback, retry, or self-repair.