### PR TITLE
Harden native subprocess supervision

### DIFF
--- a/scripts/build-windows-native.cjs
+++ b/scripts/build-windows-native.cjs
@@ -54,7 +54,9 @@ const KERNEL32_LIB = path.join(
 );
 const POWERSHELL_EXE = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
 const FSUTIL_EXE = 'C:\\Windows\\System32\\fsutil.exe';
+const WINDOWS_ROOT = 'C:\\Windows';
 const SYSTEM32 = 'C:\\Windows\\System32';
+const TASKKILL_EXE = 'C:\\Windows\\System32\\taskkill.exe';
 const EXPECTED_NODE_LIB = Object.freeze({
   byteLength: 2_869_366,
   sha256:
@@ -73,9 +75,37 @@ const REQUIRED_NODE_HEADERS = Object.freeze([
   'node_version.h',
 ]);
 const PROCESS_TIMEOUT_MS = 30_000;
+const AUTHENTICATION_TIMEOUT_MS = 90_000;
 const PROBE_TIMEOUT_MS = 10_000;
+const EXIT_CLOSE_GRACE_MS = 5_000;
+const TASKKILL_TIMEOUT_MS = 10_000;
+const POST_TERMINATION_GRACE_MS = 5_000;
 const MAX_PROCESS_OUTPUT_BYTES = 2 * 1024 * 1024;
 const MAX_JSON_BYTES = 16 * 1024;
+const SUBPROCESS_MESSAGES = Object.freeze({
+  MOXLEY_NATIVE_BUILD_SUBPROCESS_SPAWN_FAILED:
+    'Native build subprocess could not be spawned.',
+  MOXLEY_NATIVE_BUILD_SUBPROCESS_TIMED_OUT:
+    'Native build subprocess exceeded its execution bound.',
+  MOXLEY_NATIVE_BUILD_SUBPROCESS_OUTPUT_LIMIT:
+    'Native build subprocess exceeded its output bound.',
+  MOXLEY_NATIVE_BUILD_SUBPROCESS_EXIT_FAILED:
+    'Native build subprocess did not exit successfully.',
+  MOXLEY_NATIVE_BUILD_SUBPROCESS_TERMINATION_UNCONFIRMED:
+    'Native build subprocess termination could not be confirmed.',
+});
+const SUBPROCESS_REASONS = Object.freeze({
+  SPAWN_ERROR: 'SUBPROCESS_SPAWN_ERROR',
+  TIMEOUT: 'SUBPROCESS_TIMEOUT',
+  STDOUT_LIMIT: 'SUBPROCESS_STDOUT_LIMIT',
+  STDERR_LIMIT: 'SUBPROCESS_STDERR_LIMIT',
+  NONZERO_EXIT: 'SUBPROCESS_NONZERO_EXIT',
+  SIGNALLED_EXIT: 'SUBPROCESS_SIGNALLED_EXIT',
+  EXIT_WITHOUT_CLOSE: 'SUBPROCESS_EXIT_WITHOUT_CLOSE',
+  TERMINATION_TOOL_FAILED: 'SUBPROCESS_TERMINATION_TOOL_FAILED',
+  TERMINATION_NOT_CONFIRMED: 'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+});
+const TEST_CONTROL_TOKEN = Symbol('moxley-native-subprocess-test-control');
 const HEX_32 = /^[0-9a-f]{32}$/;
 const HEX_64 = /^[0-9a-f]{64}$/;
 const EXPECTED_RESULT_KEYS = Object.freeze([
@@ -177,6 +207,63 @@ function buildError(code, message) {
   return new NativeBuildError(code, message);
 }
 
+function subprocessBuildError(
+  code,
+  reason,
+  terminationConfirmed,
+  originalReason,
+) {
+  const message = SUBPROCESS_MESSAGES[code];
+  const acceptedReasons = Object.values(SUBPROCESS_REASONS);
+  if (
+    typeof message !== 'string' ||
+    !acceptedReasons.includes(reason) ||
+    typeof terminationConfirmed !== 'boolean' ||
+    (originalReason !== undefined && !acceptedReasons.includes(originalReason))
+  ) {
+    return buildError(
+      'MOXLEY_NATIVE_BUILD_FAILED',
+      'Native build failed.',
+    );
+  }
+  const error = buildError(code, message);
+  error.stack = `${error.name}: ${message}`;
+  error.reason = reason;
+  error.terminationConfirmed = terminationConfirmed;
+  if (originalReason !== undefined) {
+    error.cause = Object.freeze({ reason: originalReason });
+  }
+  return error;
+}
+
+function terminationUnconfirmedError(reason, originalReason) {
+  return subprocessBuildError(
+    'MOXLEY_NATIVE_BUILD_SUBPROCESS_TERMINATION_UNCONFIRMED',
+    reason,
+    false,
+    originalReason,
+  );
+}
+
+function isTerminationUnconfirmed(error) {
+  return (
+    error instanceof NativeBuildError &&
+    error.code ===
+      'MOXLEY_NATIVE_BUILD_SUBPROCESS_TERMINATION_UNCONFIRMED' &&
+    error.terminationConfirmed === false
+  );
+}
+
+function isSubprocessBuildError(error) {
+  return (
+    error instanceof NativeBuildError &&
+    typeof SUBPROCESS_MESSAGES[error.code] === 'string' &&
+    Object.values(SUBPROCESS_REASONS).includes(error.reason)
+  );
+}
+
+let cachedTaskkillAuthentication = null;
+
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
 }
@@ -267,92 +354,666 @@ function decodeCanonicalJson(bytes, maxBytes = MAX_JSON_BYTES) {
   return value;
 }
 
-function runProcess(file, arguments_, options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(file, arguments_, {
-      cwd: options.cwd,
-      env: options.env,
-      shell: false,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true,
-    });
-    const stdout = [];
-    const stderr = [];
+function boundedTimeout(value, fallback) {
+  const selected = value === undefined ? fallback : value;
+  if (
+    !Number.isSafeInteger(selected) ||
+    selected <= 0 ||
+    selected > 300_000
+  ) {
+    throw buildError(
+      'MOXLEY_NATIVE_BUILD_INPUT_INVALID',
+      'Native build subprocess bounds are invalid.',
+    );
+  }
+  return selected;
+}
+
+function isCanonicalTaskOwnedPid(child, pid) {
+  return (
+    child !== null &&
+    child.pid === pid &&
+    Number.isSafeInteger(pid) &&
+    pid > 0 &&
+    pid <= 0xffffffff &&
+    pid !== process.pid &&
+    pid !== process.ppid &&
+    /^[1-9][0-9]*$/.test(String(pid))
+  );
+}
+
+async function runTaskkill(
+  supervisedChild,
+  pid,
+  childHasExited,
+  onTerminationAttempt,
+) {
+  try {
+    await authenticateTerminationExecutable();
+  } catch {
+    return 'failed';
+  }
+  if (childHasExited()) return 'not-dispatched';
+  if (!isCanonicalTaskOwnedPid(supervisedChild, pid)) return 'failed';
+
+  return new Promise((resolve) => {
+    let taskkill = null;
+    let stdout = null;
+    let stderr = null;
+    let timer = null;
+    let settled = false;
+    let spawnObserved = false;
+    let exitObserved = false;
+    let closeObserved = false;
+    let stdoutCompleted = false;
+    let stderrCompleted = false;
+    let exitCode = null;
+    let exitSignal = null;
     let stdoutLength = 0;
     let stderrLength = 0;
-    let settled = false;
-    let timedOut = false;
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill();
-    }, options.timeoutMs ?? PROCESS_TIMEOUT_MS);
 
-    function finish(error, result) {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      if (error) reject(error);
-      else resolve(result);
+    function removeListeners() {
+      if (taskkill !== null) {
+        taskkill.removeListener('spawn', onSpawn);
+        taskkill.removeListener('error', onError);
+        taskkill.removeListener('exit', onExit);
+        taskkill.removeListener('close', onClose);
+      }
+      if (stdout !== null) {
+        stdout.removeListener('data', onStdoutData);
+        stdout.removeListener('end', onStdoutEnd);
+        stdout.removeListener('error', onStreamError);
+      }
+      if (stderr !== null) {
+        stderr.removeListener('data', onStderrData);
+        stderr.removeListener('end', onStderrEnd);
+        stderr.removeListener('error', onStreamError);
+      }
     }
 
-    child.once('error', (error) => finish(error));
-    child.stdout.on('data', (chunk) => {
-      stdoutLength += chunk.length;
-      if (stdoutLength > MAX_PROCESS_OUTPUT_BYTES) {
-        child.kill();
-      } else {
-        stdout.push(chunk);
+    function finish(status, stopWrapper = false) {
+      if (settled) return;
+      settled = true;
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+      if (stopWrapper && taskkill !== null && !exitObserved) {
+        try {
+          taskkill.kill();
+        } catch {
+          // A failed direct signal does not broaden termination evidence.
+        }
       }
-    });
-    child.stderr.on('data', (chunk) => {
-      stderrLength += chunk.length;
-      if (stderrLength > MAX_PROCESS_OUTPUT_BYTES) {
-        child.kill();
-      } else {
-        stderr.push(chunk);
+      removeListeners();
+      if (stopWrapper) {
+        if (stdout !== null) stdout.destroy();
+        if (stderr !== null) stderr.destroy();
+        if (taskkill !== null) taskkill.unref();
       }
-    });
-    child.once('close', (code, signal) => {
+      taskkill = null;
+      stdout = null;
+      stderr = null;
+      resolve(status);
+    }
+
+    function maybeFinish() {
       if (
-        timedOut ||
-        stdoutLength > MAX_PROCESS_OUTPUT_BYTES ||
-        stderrLength > MAX_PROCESS_OUTPUT_BYTES
+        !settled &&
+        spawnObserved &&
+        exitObserved &&
+        closeObserved &&
+        stdoutCompleted &&
+        stderrCompleted
       ) {
-        finish(
-          buildError(
-            'MOXLEY_NATIVE_BUILD_SUBPROCESS_FAILED',
-            'A bounded native build subprocess failed.',
+        finish(exitCode === 0 && exitSignal === null ? 'succeeded' : 'failed');
+      }
+    }
+
+    function onSpawn() {
+      spawnObserved = true;
+      if (onTerminationAttempt !== null) {
+        try {
+          onTerminationAttempt(
+            Object.freeze({
+              authenticatedExecutable: true,
+              canonicalPid: true,
+              tree: true,
+              force: true,
+            }),
+          );
+        } catch {
+          // Test-only observation cannot affect subprocess disposition.
+        }
+      }
+    }
+
+    function onError() {
+      finish('failed', true);
+    }
+
+    function onExit(code, signal) {
+      exitObserved = true;
+      exitCode = code;
+      exitSignal = signal;
+      maybeFinish();
+    }
+
+    function onClose() {
+      closeObserved = true;
+      maybeFinish();
+    }
+
+    function onStdoutData(chunk) {
+      stdoutLength += chunk.length;
+      if (stdoutLength > MAX_PROCESS_OUTPUT_BYTES) finish('failed', true);
+    }
+
+    function onStderrData(chunk) {
+      stderrLength += chunk.length;
+      if (stderrLength > MAX_PROCESS_OUTPUT_BYTES) finish('failed', true);
+    }
+
+    function onStdoutEnd() {
+      stdoutCompleted = true;
+      maybeFinish();
+    }
+
+    function onStderrEnd() {
+      stderrCompleted = true;
+      maybeFinish();
+    }
+
+    function onStreamError() {
+      finish('failed', true);
+    }
+
+    timer = setTimeout(() => finish('failed', true), TASKKILL_TIMEOUT_MS);
+    try {
+      taskkill = spawn(
+        TASKKILL_EXE,
+        ['/PID', String(pid), '/T', '/F'],
+        {
+          shell: false,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        },
+      );
+    } catch {
+      finish('failed');
+      return;
+    }
+    stdout = taskkill.stdout;
+    stderr = taskkill.stderr;
+    taskkill.once('spawn', onSpawn);
+    taskkill.once('error', onError);
+    taskkill.once('exit', onExit);
+    taskkill.once('close', onClose);
+    stdout.on('data', onStdoutData);
+    stdout.once('end', onStdoutEnd);
+    stdout.once('error', onStreamError);
+    stderr.on('data', onStderrData);
+    stderr.once('end', onStderrEnd);
+    stderr.once('error', onStreamError);
+  });
+}
+
+async function runProcess(file, arguments_, options = {}, testControl = null) {
+  await authenticateTerminationExecutable();
+  const timeoutMs = boundedTimeout(options.timeoutMs, PROCESS_TIMEOUT_MS);
+  const acceptedTestControl =
+    testControl !== null && testControl.token === TEST_CONTROL_TOKEN
+      ? testControl
+      : null;
+  const exitCloseGraceMs =
+    acceptedTestControl === null
+      ? EXIT_CLOSE_GRACE_MS
+      : acceptedTestControl.exitCloseGraceMs;
+  const postTerminationGraceMs =
+    acceptedTestControl === null
+      ? POST_TERMINATION_GRACE_MS
+      : acceptedTestControl.postTerminationGraceMs;
+
+  return new Promise((resolve, reject) => {
+    let child = null;
+    let stdin = null;
+    let stdout = null;
+    let stderr = null;
+    let stdoutChunks = [];
+    let stderrChunks = [];
+    let stdoutLength = 0;
+    let stderrLength = 0;
+    let executionTimer = null;
+    let exitCloseTimer = null;
+    let postTerminationTimer = null;
+    let settled = false;
+    let spawnObserved = false;
+    let exitObserved = false;
+    let closeObserved = false;
+    let stdoutCompleted = false;
+    let stderrCompleted = false;
+    let stdoutOverflowed = false;
+    let stderrOverflowed = false;
+    let acceptingOutput = true;
+    let exitCode = null;
+    let exitSignal = null;
+    let terminalTrigger = null;
+    let terminationStarted = false;
+    let terminationConfirmationReady = false;
+    let terminationOriginalReason = null;
+    let terminationObserver =
+      acceptedTestControl === null
+        ? null
+        : acceptedTestControl.onTerminationAttempt;
+
+    function clearTimers() {
+      if (executionTimer !== null) clearTimeout(executionTimer);
+      if (exitCloseTimer !== null) clearTimeout(exitCloseTimer);
+      if (postTerminationTimer !== null) clearTimeout(postTerminationTimer);
+      executionTimer = null;
+      exitCloseTimer = null;
+      postTerminationTimer = null;
+    }
+
+    function removeListeners() {
+      if (child !== null) {
+        child.removeListener('spawn', onSpawn);
+        child.removeListener('error', onChildError);
+        child.removeListener('exit', onExit);
+        child.removeListener('close', onClose);
+      }
+      if (stdin !== null) stdin.removeListener('error', onStdinError);
+      if (stdout !== null) {
+        stdout.removeListener('data', onStdoutData);
+        stdout.removeListener('end', onStdoutEnd);
+        stdout.removeListener('error', onStdoutError);
+      }
+      if (stderr !== null) {
+        stderr.removeListener('data', onStderrData);
+        stderr.removeListener('end', onStderrEnd);
+        stderr.removeListener('error', onStderrError);
+      }
+    }
+
+    function releaseReferences(releaseOpenHandles) {
+      removeListeners();
+      if (releaseOpenHandles) {
+        if (stdin !== null) stdin.destroy();
+        if (stdout !== null) stdout.destroy();
+        if (stderr !== null) stderr.destroy();
+        if (child !== null) child.unref();
+      }
+      child = null;
+      stdin = null;
+      stdout = null;
+      stderr = null;
+      stdoutChunks.length = 0;
+      stderrChunks.length = 0;
+      stdoutChunks = null;
+      stderrChunks = null;
+      terminationObserver = null;
+    }
+
+    function settleError(error) {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      releaseReferences(!closeObserved);
+      reject(error);
+    }
+
+    function settleResult() {
+      if (settled) return;
+      const result = Object.freeze({
+        code: exitCode,
+        signal: exitSignal,
+        stdout: Buffer.concat(stdoutChunks, stdoutLength),
+        stderr: Buffer.concat(stderrChunks, stderrLength),
+      });
+      settled = true;
+      clearTimers();
+      releaseReferences(false);
+      resolve(result);
+    }
+
+    function selectTerminalTrigger(kind, reason) {
+      if (settled || terminalTrigger !== null) return false;
+      terminalTrigger = Object.freeze({ kind, reason });
+      return true;
+    }
+
+    function hasExplainableExit() {
+      return (
+        (Number.isInteger(exitCode) && exitSignal === null) ||
+        (exitCode === null &&
+          typeof exitSignal === 'string' &&
+          exitSignal.length !== 0)
+      );
+    }
+
+    function originalTerminationConfirmed() {
+      return (
+        exitObserved &&
+        stdoutCompleted &&
+        stderrCompleted &&
+        closeObserved
+      );
+    }
+
+    function confirmedTerminationError() {
+      if (terminationOriginalReason === SUBPROCESS_REASONS.TIMEOUT) {
+        return subprocessBuildError(
+          'MOXLEY_NATIVE_BUILD_SUBPROCESS_TIMED_OUT',
+          terminationOriginalReason,
+          true,
+        );
+      }
+      if (
+        terminationOriginalReason === SUBPROCESS_REASONS.STDOUT_LIMIT ||
+        terminationOriginalReason === SUBPROCESS_REASONS.STDERR_LIMIT
+      ) {
+        return subprocessBuildError(
+          'MOXLEY_NATIVE_BUILD_SUBPROCESS_OUTPUT_LIMIT',
+          terminationOriginalReason,
+          true,
+        );
+      }
+      return subprocessBuildError(
+        'MOXLEY_NATIVE_BUILD_SUBPROCESS_EXIT_FAILED',
+        SUBPROCESS_REASONS.EXIT_WITHOUT_CLOSE,
+        true,
+      );
+    }
+
+    function maybeFinishTerminationConfirmation() {
+      if (
+        settled ||
+        !terminationStarted ||
+        !terminationConfirmationReady
+      ) {
+        return;
+      }
+      if (originalTerminationConfirmed()) {
+        settleError(confirmedTerminationError());
+      }
+    }
+
+    function beginPostTerminationConfirmation() {
+      if (settled) return;
+      terminationConfirmationReady = true;
+      if (originalTerminationConfirmed()) {
+        settleError(confirmedTerminationError());
+        return;
+      }
+      postTerminationTimer = setTimeout(() => {
+        postTerminationTimer = null;
+        settleError(
+          terminationUnconfirmedError(
+            SUBPROCESS_REASONS.TERMINATION_NOT_CONFIRMED,
+            terminationOriginalReason,
+          ),
+        );
+      }, postTerminationGraceMs);
+    }
+
+    async function beginTermination(reason) {
+      if (settled || terminationStarted) return;
+      terminationStarted = true;
+      terminationOriginalReason = reason;
+      acceptingOutput = false;
+      if (executionTimer !== null) clearTimeout(executionTimer);
+      if (exitCloseTimer !== null) clearTimeout(exitCloseTimer);
+      executionTimer = null;
+      exitCloseTimer = null;
+
+      if (exitObserved) {
+        beginPostTerminationConfirmation();
+        return;
+      }
+      if (!spawnObserved || child === null) {
+        settleError(
+          terminationUnconfirmedError(
+            SUBPROCESS_REASONS.TERMINATION_TOOL_FAILED,
+            terminationOriginalReason,
           ),
         );
         return;
       }
-      finish(null, {
-        code,
-        signal,
-        stdout: Buffer.concat(stdout),
-        stderr: Buffer.concat(stderr),
-      });
-    });
 
-    if (options.stdin === undefined) child.stdin.end();
-    else child.stdin.end(options.stdin);
+      const supervisedChild = child;
+      const pid = supervisedChild.pid;
+      const taskkillResult = await runTaskkill(
+        supervisedChild,
+        pid,
+        () => exitObserved,
+        terminationObserver,
+      );
+      if (settled) return;
+      if (taskkillResult === 'failed') {
+        settleError(
+          terminationUnconfirmedError(
+            SUBPROCESS_REASONS.TERMINATION_TOOL_FAILED,
+            terminationOriginalReason,
+          ),
+        );
+        return;
+      }
+      beginPostTerminationConfirmation();
+    }
+
+    function maybeFinishExit() {
+      if (
+        settled ||
+        terminationStarted ||
+        terminalTrigger === null ||
+        terminalTrigger.kind !== 'exit'
+      ) {
+        return;
+      }
+      if (
+        exitObserved &&
+        stdoutCompleted &&
+        stderrCompleted &&
+        closeObserved &&
+        !stdoutOverflowed &&
+        !stderrOverflowed &&
+        hasExplainableExit()
+      ) {
+        settleResult();
+        return;
+      }
+      if (exitObserved && exitCloseTimer === null) {
+        exitCloseTimer = setTimeout(() => {
+          exitCloseTimer = null;
+          void beginTermination(SUBPROCESS_REASONS.EXIT_WITHOUT_CLOSE);
+        }, exitCloseGraceMs);
+      }
+    }
+
+    function onSpawn() {
+      spawnObserved = true;
+      if (
+        acceptedTestControl !== null &&
+        acceptedTestControl.signalAfterSpawn
+      ) {
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          // The execution timer remains the bound if the test-only signal fails.
+        }
+      }
+    }
+
+    function onChildError() {
+      if (!spawnObserved && selectTerminalTrigger('spawn-error', SUBPROCESS_REASONS.SPAWN_ERROR)) {
+        settleError(
+          subprocessBuildError(
+            'MOXLEY_NATIVE_BUILD_SUBPROCESS_SPAWN_FAILED',
+            SUBPROCESS_REASONS.SPAWN_ERROR,
+            false,
+          ),
+        );
+      }
+    }
+
+    function onExit(code, signal) {
+      exitObserved = true;
+      exitCode = code;
+      exitSignal = signal;
+      if (selectTerminalTrigger('exit', null)) {
+        if (executionTimer !== null) clearTimeout(executionTimer);
+        executionTimer = null;
+        maybeFinishExit();
+      } else {
+        maybeFinishTerminationConfirmation();
+      }
+    }
+
+    function onClose() {
+      closeObserved = true;
+      maybeFinishExit();
+      maybeFinishTerminationConfirmation();
+    }
+
+    function retainChunk(chunks, chunk, length) {
+      const remaining = MAX_PROCESS_OUTPUT_BYTES - length;
+      if (remaining <= 0) return 0;
+      const accepted = Math.min(remaining, chunk.length);
+      if (accepted !== 0) chunks.push(chunk.subarray(0, accepted));
+      return accepted;
+    }
+
+    function onStdoutData(chunk) {
+      if (!acceptingOutput) return;
+      const accepted = retainChunk(stdoutChunks, chunk, stdoutLength);
+      stdoutLength += accepted;
+      if (accepted !== chunk.length) {
+        if (
+          selectTerminalTrigger(
+            'stdout-overflow',
+            SUBPROCESS_REASONS.STDOUT_LIMIT,
+          )
+        ) {
+          stdoutOverflowed = true;
+          acceptingOutput = false;
+          void beginTermination(SUBPROCESS_REASONS.STDOUT_LIMIT);
+        }
+      }
+    }
+
+    function onStderrData(chunk) {
+      if (!acceptingOutput) return;
+      const accepted = retainChunk(stderrChunks, chunk, stderrLength);
+      stderrLength += accepted;
+      if (accepted !== chunk.length) {
+        if (
+          selectTerminalTrigger(
+            'stderr-overflow',
+            SUBPROCESS_REASONS.STDERR_LIMIT,
+          )
+        ) {
+          stderrOverflowed = true;
+          acceptingOutput = false;
+          void beginTermination(SUBPROCESS_REASONS.STDERR_LIMIT);
+        }
+      }
+    }
+
+    function onStdoutEnd() {
+      stdoutCompleted = true;
+      maybeFinishExit();
+      maybeFinishTerminationConfirmation();
+    }
+
+    function onStderrEnd() {
+      stderrCompleted = true;
+      maybeFinishExit();
+      maybeFinishTerminationConfirmation();
+    }
+
+    function onStdinError() {
+      // Stdin failure is bounded by the existing terminal-trigger state machine.
+    }
+
+    function onStdoutError() {
+      stdoutCompleted = false;
+    }
+
+    function onStderrError() {
+      stderrCompleted = false;
+    }
+
+    function onExecutionTimeout() {
+      executionTimer = null;
+      if (selectTerminalTrigger('timeout', SUBPROCESS_REASONS.TIMEOUT)) {
+        acceptingOutput = false;
+        void beginTermination(SUBPROCESS_REASONS.TIMEOUT);
+      }
+    }
+
+    executionTimer = setTimeout(onExecutionTimeout, timeoutMs);
+    try {
+      child = spawn(file, arguments_, {
+        cwd: options.cwd,
+        env: options.env,
+        shell: false,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch {
+      selectTerminalTrigger('spawn-error', SUBPROCESS_REASONS.SPAWN_ERROR);
+      settleError(
+        subprocessBuildError(
+          'MOXLEY_NATIVE_BUILD_SUBPROCESS_SPAWN_FAILED',
+          SUBPROCESS_REASONS.SPAWN_ERROR,
+          false,
+        ),
+      );
+      return;
+    }
+
+    stdin = child.stdin;
+    stdout = child.stdout;
+    stderr = child.stderr;
+    child.once('spawn', onSpawn);
+    child.on('error', onChildError);
+    child.once('exit', onExit);
+    child.once('close', onClose);
+    stdin.on('error', onStdinError);
+    stdout.on('data', onStdoutData);
+    stdout.once('end', onStdoutEnd);
+    stdout.on('error', onStdoutError);
+    stderr.on('data', onStderrData);
+    stderr.once('end', onStderrEnd);
+    stderr.on('error', onStderrError);
+
+    try {
+      if (options.stdin === undefined) stdin.end();
+      else stdin.end(options.stdin);
+    } catch {
+      // Invalid or closed stdin cannot escape the bounded state machine.
+    }
   });
 }
 
-async function requireProcessSuccess(label, file, arguments_, options) {
-  let result;
-  try {
-    result = await runProcess(file, arguments_, options);
-  } catch {
-    throw buildError(
-      'MOXLEY_NATIVE_BUILD_SUBPROCESS_FAILED',
-      `${label} failed.`,
+async function requireProcessSuccess(
+  label,
+  file,
+  arguments_,
+  options,
+  testControl = null,
+) {
+  const result = await runProcess(file, arguments_, options, testControl);
+  if (result.signal !== null) {
+    throw subprocessBuildError(
+      'MOXLEY_NATIVE_BUILD_SUBPROCESS_EXIT_FAILED',
+      SUBPROCESS_REASONS.SIGNALLED_EXIT,
+      true,
     );
   }
-  if (result.code !== 0 || result.signal !== null) {
-    throw buildError(
-      'MOXLEY_NATIVE_BUILD_SUBPROCESS_FAILED',
-      `${label} failed.`,
+  if (result.code !== 0) {
+    throw subprocessBuildError(
+      'MOXLEY_NATIVE_BUILD_SUBPROCESS_EXIT_FAILED',
+      SUBPROCESS_REASONS.NONZERO_EXIT,
+      true,
     );
   }
   const output = Buffer.concat([result.stdout, result.stderr]).toString('utf8');
@@ -363,6 +1024,75 @@ async function requireProcessSuccess(label, file, arguments_, options) {
     );
   }
   return result;
+}
+
+function testProcessInvocation(options = {}) {
+  const productionOptions = { ...options };
+  const exitCloseGraceMs = productionOptions.exitCloseGraceMs;
+  const postTerminationGraceMs = productionOptions.postTerminationGraceMs;
+  const onTerminationAttempt = productionOptions.onTerminationAttempt;
+  const signalAfterSpawn = productionOptions.signalAfterSpawn;
+  delete productionOptions.exitCloseGraceMs;
+  delete productionOptions.postTerminationGraceMs;
+  delete productionOptions.onTerminationAttempt;
+  delete productionOptions.signalAfterSpawn;
+
+  function testGrace(value, fallback) {
+    if (value === undefined) return fallback;
+    if (!Number.isSafeInteger(value) || value <= 0 || value > fallback) {
+      throw buildError(
+        'MOXLEY_NATIVE_BUILD_TEST_SCOPE_INVALID',
+        'Injected native build test scope is invalid.',
+      );
+    }
+    return value;
+  }
+
+  if (
+    onTerminationAttempt !== undefined &&
+    typeof onTerminationAttempt !== 'function'
+  ) {
+    throw buildError(
+      'MOXLEY_NATIVE_BUILD_TEST_SCOPE_INVALID',
+      'Injected native build test scope is invalid.',
+    );
+  }
+  if (signalAfterSpawn !== undefined && signalAfterSpawn !== true) {
+    throw buildError(
+      'MOXLEY_NATIVE_BUILD_TEST_SCOPE_INVALID',
+      'Injected native build test scope is invalid.',
+    );
+  }
+
+  return Object.freeze({
+    options: productionOptions,
+    control: Object.freeze({
+      token: TEST_CONTROL_TOKEN,
+      exitCloseGraceMs: testGrace(exitCloseGraceMs, EXIT_CLOSE_GRACE_MS),
+      postTerminationGraceMs: testGrace(
+        postTerminationGraceMs,
+        POST_TERMINATION_GRACE_MS,
+      ),
+      onTerminationAttempt: onTerminationAttempt ?? null,
+      signalAfterSpawn: signalAfterSpawn === true,
+    }),
+  });
+}
+
+function runProcessForTest(file, arguments_, options) {
+  const invocation = testProcessInvocation(options);
+  return runProcess(file, arguments_, invocation.options, invocation.control);
+}
+
+function requireProcessSuccessForTest(label, file, arguments_, options) {
+  const invocation = testProcessInvocation(options);
+  return requireProcessSuccess(
+    label,
+    file,
+    arguments_,
+    invocation.options,
+    invocation.control,
+  );
 }
 
 function encodedPowerShell(command) {
@@ -384,7 +1114,7 @@ async function runPowerShellJson(command, environment) {
     ],
     {
       env: { ...process.env, ...environment },
-      timeoutMs: PROCESS_TIMEOUT_MS,
+      timeoutMs: AUTHENTICATION_TIMEOUT_MS,
     },
   );
   const stdout = result.stdout.toString('utf8').trim();
@@ -410,7 +1140,8 @@ async function assertNoReparse(target) {
     result = await runProcess(FSUTIL_EXE, ['reparsepoint', 'query', target], {
       timeoutMs: PROCESS_TIMEOUT_MS,
     });
-  } catch {
+  } catch (error) {
+    if (isSubprocessBuildError(error)) throw error;
     throw buildError(
       'MOXLEY_NATIVE_BUILD_PATH_INVALID',
       'A native build path could not be authenticated.',
@@ -475,6 +1206,71 @@ function sameIdentity(metadata, identity, includeSize = true) {
     (identity.type === 'file' ? metadata.isFile() : metadata.isDirectory()) &&
     !metadata.isSymbolicLink()
   );
+}
+
+async function authenticateTerminationExecutable() {
+  if (cachedTaskkillAuthentication !== null) {
+    return cachedTaskkillAuthentication;
+  }
+
+  try {
+    const windowsMetadata = await fsp.lstat(WINDOWS_ROOT, { bigint: true });
+    const system32Metadata = await fsp.lstat(SYSTEM32, { bigint: true });
+    const executableMetadata = await fsp.lstat(TASKKILL_EXE, { bigint: true });
+    if (
+      !windowsMetadata.isDirectory() ||
+      windowsMetadata.isSymbolicLink() ||
+      !system32Metadata.isDirectory() ||
+      system32Metadata.isSymbolicLink() ||
+      !executableMetadata.isFile() ||
+      executableMetadata.isSymbolicLink()
+    ) {
+      throw new Error('TERMINATION_EXECUTABLE_TYPE_INVALID');
+    }
+
+    const canonicalWindows = await fsp.realpath(WINDOWS_ROOT);
+    const canonicalSystem32 = await fsp.realpath(SYSTEM32);
+    const canonicalExecutable = await fsp.realpath(TASKKILL_EXE);
+    if (
+      !sameWindowsPath(canonicalWindows, WINDOWS_ROOT) ||
+      !sameWindowsPath(canonicalSystem32, SYSTEM32) ||
+      !sameWindowsPath(canonicalExecutable, TASKKILL_EXE)
+    ) {
+      throw new Error('TERMINATION_EXECUTABLE_CANONICAL_INVALID');
+    }
+
+    const canonicalWindowsMetadata = await fsp.stat(canonicalWindows, {
+      bigint: true,
+    });
+    const canonicalSystem32Metadata = await fsp.stat(canonicalSystem32, {
+      bigint: true,
+    });
+    const canonicalExecutableMetadata = await fsp.stat(canonicalExecutable, {
+      bigint: true,
+    });
+    const windowsIdentity = identityOf(windowsMetadata);
+    const system32Identity = identityOf(system32Metadata);
+    const executableIdentity = identityOf(executableMetadata);
+    if (
+      !sameIdentity(canonicalWindowsMetadata, windowsIdentity, false) ||
+      !sameIdentity(canonicalSystem32Metadata, system32Identity, false) ||
+      !sameIdentity(canonicalExecutableMetadata, executableIdentity, true)
+    ) {
+      throw new Error('TERMINATION_EXECUTABLE_IDENTITY_INVALID');
+    }
+
+    const authenticated = Object.freeze({
+      windowsRoot: windowsIdentity,
+      system32: system32Identity,
+      executable: executableIdentity,
+    });
+    cachedTaskkillAuthentication = authenticated;
+    return authenticated;
+  } catch {
+    throw terminationUnconfirmedError(
+      SUBPROCESS_REASONS.TERMINATION_TOOL_FAILED,
+    );
+  }
 }
 
 async function assertAbsent(target, collision = false) {
@@ -1307,7 +2103,8 @@ async function runProbe(addonPath, probePath) {
     addonPath,
     probePath,
   });
-  const result = await runProcess(
+  const result = await requireProcessSuccess(
+    'Native addon probe',
     process.execPath,
     ['-e', PROBE_WORKER_SOURCE],
     {
@@ -1320,11 +2117,7 @@ async function runProbe(addonPath, probePath) {
       },
     },
   );
-  if (
-    result.code !== 0 ||
-    result.signal !== null ||
-    result.stderr.length !== 0
-  ) {
+  if (result.stderr.length !== 0) {
     throw buildError(
       'MOXLEY_NATIVE_BUILD_PROBE_FAILED',
       'Native addon probe failed.',
@@ -1549,6 +2342,14 @@ async function promoteAndFinalize(context) {
 }
 
 async function handleBuildFailure(state, originalError) {
+  if (isTerminationUnconfirmed(originalError)) {
+    if (state.lease !== null) {
+      await state.lease.close().catch(() => {});
+      state.lease = null;
+    }
+    throw originalError;
+  }
+
   let failure = originalError;
   if (!state.firstPromotionOccurred) {
     try {
@@ -1667,7 +2468,13 @@ async function exercisePromotionScenario(sandboxRoot, mode) {
   if (
     path.dirname(canonicalSandbox).toLowerCase() !== tempRoot.toLowerCase() ||
     !path.basename(canonicalSandbox).startsWith('moxley-native-build-test-') ||
-    !['success', 'pre', 'post'].includes(mode)
+    ![
+      'success',
+      'pre',
+      'post',
+      'termination-unconfirmed-pre',
+      'termination-unconfirmed-post',
+    ].includes(mode)
   ) {
     throw buildError(
       'MOXLEY_NATIVE_BUILD_TEST_SCOPE_INVALID',
@@ -1727,20 +2534,29 @@ async function exercisePromotionScenario(sandboxRoot, mode) {
       'moxley-windows-reparse-probe.txt',
     ]),
   };
+  function injectedFailure(code, message) {
+    if (mode.startsWith('termination-unconfirmed-')) {
+      return terminationUnconfirmedError(
+        SUBPROCESS_REASONS.TERMINATION_NOT_CONFIRMED,
+        SUBPROCESS_REASONS.TIMEOUT,
+      );
+    }
+    return buildError(code, message);
+  }
   const hooks = {
     beforeBinaryPromotion:
-      mode === 'pre'
+      mode === 'pre' || mode === 'termination-unconfirmed-pre'
         ? async () => {
-            throw buildError(
+            throw injectedFailure(
               'MOXLEY_NATIVE_BUILD_INJECTED_FAILURE',
               'Injected pre-promotion failure.',
             );
           }
         : undefined,
     afterBinaryPromotion:
-      mode === 'post'
+      mode === 'post' || mode === 'termination-unconfirmed-post'
         ? async () => {
-            throw buildError(
+            throw injectedFailure(
               'MOXLEY_NATIVE_BUILD_INJECTED_FAILURE',
               'Injected post-promotion failure.',
             );
@@ -1778,6 +2594,12 @@ async function exercisePromotionScenario(sandboxRoot, mode) {
         observations,
         failed: true,
         code: handled.code,
+        reason: handled.reason,
+        terminationConfirmed: handled.terminationConfirmed,
+        causeReason:
+          handled.cause && typeof handled.cause.reason === 'string'
+            ? handled.cause.reason
+            : undefined,
       };
     }
   }
@@ -1855,16 +2677,21 @@ const internal = Object.freeze({
 module.exports = Object.freeze({
   internal,
   __test: Object.freeze({
+    AUTHENTICATION_TIMEOUT_MS,
+    EXIT_CLOSE_GRACE_MS,
     MAX_PROCESS_OUTPUT_BYTES,
+    POST_TERMINATION_GRACE_MS,
     PROCESS_TIMEOUT_MS,
+    PROBE_TIMEOUT_MS,
+    TASKKILL_TIMEOUT_MS,
     authenticateBuildInputs,
     createReceipt,
     decodeReceiptBytes,
     exercisePromotionScenario,
-    requireProcessSuccess,
+    requireProcessSuccess: requireProcessSuccessForTest,
     repositoryLeaseIdentity,
     runBuild,
-    runProcess,
+    runProcess: runProcessForTest,
     validateReceipt,
   }),
 });

--- a/test/windows-native-build.test.cjs
+++ b/test/windows-native-build.test.cjs
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const { spawn } = require('node:child_process');
 const { createHash } = require('node:crypto');
 const fsp = require('node:fs/promises');
 const net = require('node:net');
@@ -50,12 +49,260 @@ const LOCK = path.join(
   '.moxley-windows-reparse-build.lock',
 );
 const STAGING_PREFIX = '.moxley-windows-reparse-stage-';
-const PROCESS_TIMEOUT_MS = 120_000;
-const MAX_OUTPUT_BYTES = 1024 * 1024;
+const HARNESS_PROCESS_TIMEOUT_MS = 300_000;
+const POWERSHELL_EXE = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+const SUBPROCESS_CODES = Object.freeze({
+  spawn: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_SPAWN_FAILED',
+  timeout: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_TIMED_OUT',
+  output: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_OUTPUT_LIMIT',
+  exit: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_EXIT_FAILED',
+  termination:
+    'MOXLEY_NATIVE_BUILD_SUBPROCESS_TERMINATION_UNCONFIRMED',
+});
+const SUBPROCESS_REASONS = Object.freeze([
+  'SUBPROCESS_SPAWN_ERROR',
+  'SUBPROCESS_TIMEOUT',
+  'SUBPROCESS_STDOUT_LIMIT',
+  'SUBPROCESS_STDERR_LIMIT',
+  'SUBPROCESS_NONZERO_EXIT',
+  'SUBPROCESS_SIGNALLED_EXIT',
+  'SUBPROCESS_EXIT_WITHOUT_CLOSE',
+  'SUBPROCESS_TERMINATION_TOOL_FAILED',
+  'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+]);
+const INVENTORY_PROCESS_SOURCE = String.raw`
+$ErrorActionPreference='Stop'
+$ProgressPreference='SilentlyContinue'
+$OutputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new($false)
+$requestText=[Console]::In.ReadToEnd()
+if ($requestText.Length -le 0 -or $requestText.Length -gt 4096) {
+  throw 'PROCESS_REQUEST_INVALID'
+}
+try {
+  $request=ConvertFrom-Json $requestText
+} catch {
+  throw 'PROCESS_REQUEST_INVALID'
+}
+if (
+  ($request.PSObject.Properties.Name -join ',') -ne
+    'rootPid,buildScript,cleanScript,release' -or
+  ($request.rootPid -isnot [long] -and $request.rootPid -isnot [int]) -or
+  $request.rootPid -le 0 -or
+  $request.rootPid -gt [int]::MaxValue
+) {
+  throw 'PROCESS_REQUEST_INVALID'
+}
+foreach ($expectedPath in @(
+  $request.buildScript,
+  $request.cleanScript,
+  $request.release
+)) {
+  if (
+    $expectedPath -isnot [string] -or
+    $expectedPath.Length -le 0 -or
+    $expectedPath.Length -gt 1024 -or
+    ![IO.Path]::IsPathFullyQualified($expectedPath)
+  ) {
+    throw 'PROCESS_REQUEST_INVALID'
+  }
+}
+$testRootPid=[int64]$request.rootPid
+if ($testRootPid -gt [int]::MaxValue -or $testRootPid -eq $PID) {
+  throw 'PROCESS_ROOT_INVALID'
+}
+$snapshot=@(Get-CimInstance -ClassName Win32_Process)
+if ($snapshot.Count -gt 8192) { throw 'PROCESS_SNAPSHOT_LIMIT' }
+$byPid=@{}
+foreach ($entry in $snapshot) {
+  $entryPid=[int64]$entry.ProcessId
+  $parentPid=[int64]$entry.ParentProcessId
+  if (
+    $entryPid -lt 0 -or
+    $entryPid -gt [int]::MaxValue -or
+    $parentPid -lt 0 -or
+    $parentPid -gt [int]::MaxValue -or
+    $byPid.ContainsKey([int]$entryPid)
+  ) {
+    throw 'PROCESS_SNAPSHOT_INVALID'
+  }
+  $byPid.Add([int]$entryPid,$entry)
+}
+if (!$byPid.ContainsKey([int]$testRootPid)) { throw 'PROCESS_ROOT_INVALID' }
+if ([string]$byPid[[int]$testRootPid].Name -ne 'node.exe') {
+  throw 'PROCESS_ROOT_INVALID'
+}
+function Get-CreationTicks($entry) {
+  if ($null -eq $entry.CreationDate) { return $null }
+  try {
+    return ([datetime]$entry.CreationDate).ToUniversalTime().Ticks
+  } catch {
+    return $null
+  }
+}
+$testRootCreationTicks=Get-CreationTicks $byPid[[int]$testRootPid]
+if ($null -eq $testRootCreationTicks) { throw 'PROCESS_ROOT_INVALID' }
+function Get-TaskAncestry($candidate) {
+  $seen=[System.Collections.Generic.HashSet[int]]::new()
+  $current=$candidate
+  $currentTicks=Get-CreationTicks $current
+  if ($null -eq $currentTicks) { return 'ambiguous' }
+  if ($currentTicks -lt $testRootCreationTicks) { return 'other' }
+  for ($depth=0; $depth -lt 64; $depth++) {
+    $currentPid=[int]$current.ProcessId
+    if (!$seen.Add($currentPid)) { return 'ambiguous' }
+    $parentPid=[int]$current.ParentProcessId
+    if ($parentPid -le 0) { return 'other' }
+    if (!$byPid.ContainsKey($parentPid)) { return 'ambiguous' }
+    $parent=$byPid[$parentPid]
+    $parentTicks=Get-CreationTicks $parent
+    if ($null -eq $parentTicks -or $parentTicks -gt $currentTicks) {
+      return 'ambiguous'
+    }
+    if ($parentPid -eq [int]$PID) {
+      if ($parentTicks -ne $inventoryCreationTicks) { return 'ambiguous' }
+      return 'census-rooted'
+    }
+    if ($parentPid -eq [int]$testRootPid) {
+      if ($parentTicks -ne $testRootCreationTicks) { return 'ambiguous' }
+      return 'task-rooted'
+    }
+    if ($parentTicks -lt $testRootCreationTicks) { return 'other' }
+    $current=$parent
+    $currentTicks=$parentTicks
+  }
+  return 'ambiguous'
+}
+function Test-ContainsOrdinalIgnoreCase([string]$text,[string]$value) {
+  return $text.IndexOf($value,[StringComparison]::OrdinalIgnoreCase) -ge 0
+}
+function Get-TaskRole($entry) {
+  $name=[string]$entry.Name
+  $command=[string]$entry.CommandLine
+  if ($name -eq 'node.exe') {
+    if (Test-ContainsOrdinalIgnoreCase $command $request.buildScript) {
+      return 'native-build-node'
+    }
+    if (Test-ContainsOrdinalIgnoreCase $command $request.cleanScript) {
+      return 'native-clean-node'
+    }
+    if (Test-ContainsOrdinalIgnoreCase $command 'moxley-native-build-probe') {
+      return 'native-probe-node'
+    }
+    return $null
+  }
+  if ($name -eq 'cl.exe') {
+    if (
+      (Test-ContainsOrdinalIgnoreCase $command $request.release) -and
+      (Test-ContainsOrdinalIgnoreCase $command 'moxley-windows-reparse-compile.rsp')
+    ) {
+      return 'native-compiler'
+    }
+    return $null
+  }
+  if ($name -eq 'link.exe') {
+    if (
+      (Test-ContainsOrdinalIgnoreCase $command $request.release) -and
+      (Test-ContainsOrdinalIgnoreCase $command 'moxley-windows-reparse-link.rsp')
+    ) {
+      return 'native-linker'
+    }
+    return $null
+  }
+  if ($name -eq 'pwsh.exe') {
+    if ($command -match '^"?C:\\Program Files\\PowerShell\\7\\pwsh\.exe"?\s+-NoLogo\s+-NoProfile\s+-NonInteractive\s+-ExecutionPolicy\s+Bypass\s+-EncodedCommand\s+[A-Za-z0-9+/=]+\s*$') {
+      return 'bounded-powershell'
+    }
+    return $null
+  }
+  if ($name -eq 'taskkill.exe') {
+    if ($command -match '^"?C:\\Windows\\System32\\taskkill\.exe"?\s+/PID\s+[1-9][0-9]*\s+/T\s+/F\s*$') {
+      return 'taskkill-tree'
+    }
+    return $null
+  }
+  if ($name -eq 'fsutil.exe') {
+    if ($command -match '^"?C:\\Windows\\System32\\fsutil\.exe"?\s+reparsepoint\s+query\s+.+$') {
+      return 'filesystem-authentication'
+    }
+    return $null
+  }
+  if ($name -eq 'vswhere.exe') {
+    if (
+      $command -match '^"?C:\\Program Files \(x86\)\\Microsoft Visual Studio\\Installer\\vswhere\.exe"?\s+-products\s+Microsoft\.VisualStudio\.Product\.BuildTools\s+-property\s+installationVersion\s*$'
+    ) {
+      return 'visual-studio-authentication'
+    }
+    return $null
+  }
+  return $null
+}
+function Test-ExplicitMoxleyRole([string]$role) {
+  return $role -in @(
+    'native-build-node',
+    'native-clean-node',
+    'native-probe-node',
+    'native-compiler',
+    'native-linker'
+  )
+}
+$inventoryEntry=$byPid[[int]$PID]
+$inventoryCreationTicks=Get-CreationTicks $inventoryEntry
+if (
+  $null -eq $inventoryEntry -or
+  [string]$inventoryEntry.Name -ne 'pwsh.exe' -or
+  [int]$inventoryEntry.ParentProcessId -ne [int]$testRootPid -or
+  $null -eq $inventoryCreationTicks -or
+  $inventoryCreationTicks -lt $testRootCreationTicks -or
+  (Get-TaskRole $inventoryEntry) -ne 'bounded-powershell'
+) {
+  throw 'PROCESS_CENSUS_IDENTITY_INVALID'
+}
+$items=[System.Collections.Generic.List[object]]::new()
+foreach ($entry in $snapshot) {
+  if ($entry.ProcessId -eq $PID -or $entry.ProcessId -eq $testRootPid) {
+    continue
+  }
+  $ancestry=Get-TaskAncestry $entry
+  if ($ancestry -eq 'census-rooted') { continue }
+  $role=Get-TaskRole $entry
+  $boundedName=[string]$entry.Name
+  if ($ancestry -eq 'task-rooted' -and $null -eq $role) {
+    $role='other-task-descendant'
+    $boundedName='task-descendant'
+  } elseif ($null -eq $role) {
+    continue
+  }
+  $explicit=Test-ExplicitMoxleyRole $role
+  if ($ancestry -eq 'other' -and !$explicit) { continue }
+  $classification=if ($ancestry -eq 'task-rooted') {
+    'task-rooted'
+  } elseif ($explicit) {
+    'moxley-command'
+  } else {
+    'ambiguous'
+  }
+  $creationTicks=Get-CreationTicks $entry
+  if ($null -eq $creationTicks) { throw 'PROCESS_CREATION_INVALID' }
+  [void]$items.Add([pscustomobject][ordered]@{
+    name=$boundedName
+    role=$role
+    processId=[int]$entry.ProcessId
+    parentProcessId=[int]$entry.ParentProcessId
+    creationToken=$creationTicks.ToString([Globalization.CultureInfo]::InvariantCulture)
+    classification=$classification
+  })
+}
+$items=@($items | Sort-Object processId)
+if ($items.Count -gt 128) { throw 'PROCESS_INVENTORY_LIMIT' }
+[Console]::Out.Write((ConvertTo-Json -Compress -InputObject @($items)))
+`;
 const sandboxRoots = new Set();
 let repositoryBuildOwned = false;
 let liveServer = null;
 let liveLockOwned = false;
+let ambiguousProcessBaseline = new Set();
+let uncertainRepositoryState = false;
+let lastUncertainInventory = null;
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -71,48 +318,354 @@ async function exists(target) {
   }
 }
 
-function runProcess(file, arguments_, options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(file, arguments_, {
-      cwd: options.cwd,
-      env: process.env,
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: true,
-    });
-    const stdout = [];
-    const stderr = [];
-    let stdoutLength = 0;
-    let stderrLength = 0;
+function encodedPowerShell(command) {
+  return Buffer.from(command, 'utf16le').toString('base64');
+}
+
+function processEvidenceKey(processEvidence) {
+  return [
+    processEvidence.name,
+    processEvidence.processId,
+    processEvidence.creationToken,
+  ].join(':');
+}
+
+async function captureCandidateProcesses() {
+  let result;
+  try {
+    result = await buildTest.runProcess(
+      POWERSHELL_EXE,
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-EncodedCommand',
+        encodedPowerShell(INVENTORY_PROCESS_SOURCE),
+      ],
+      {
+        env: process.env,
+        stdin: Buffer.from(JSON.stringify({
+          rootPid: process.pid,
+          buildScript: BUILD_SCRIPT,
+          cleanScript: CLEAN_SCRIPT,
+          release: RELEASE,
+        }), 'utf8'),
+        timeoutMs: HARNESS_PROCESS_TIMEOUT_MS,
+      },
+    );
+  } catch (error) {
+    if (
+      error?.code === SUBPROCESS_CODES.timeout ||
+      error?.code === SUBPROCESS_CODES.termination
+    ) {
+      uncertainRepositoryState = true;
+    }
+    return { confirmed: false, processes: [] };
+  }
+  if (
+    result.code !== 0 ||
+    result.signal !== null ||
+    result.stderr.length !== 0 ||
+    result.stdout.length === 0 ||
+    result.stdout.length > 64 * 1024
+  ) {
+    return { confirmed: false, processes: [] };
+  }
+  let value;
+  try {
+    value = JSON.parse(result.stdout.toString('utf8'));
+  } catch {
+    return { confirmed: false, processes: [] };
+  }
+  if (!Array.isArray(value) || value.length > 128) {
+    return { confirmed: false, processes: [] };
+  }
+  const acceptedNames = new Set([
+    'cl.exe',
+    'fsutil.exe',
+    'link.exe',
+    'node.exe',
+    'pwsh.exe',
+    'task-descendant',
+    'taskkill.exe',
+    'vswhere.exe',
+  ]);
+  const processes = [];
+  for (const entry of value) {
+    if (
+      entry === null ||
+      typeof entry !== 'object' ||
+      Array.isArray(entry) ||
+      JSON.stringify(Object.keys(entry)) !==
+        JSON.stringify([
+          'name',
+          'role',
+          'processId',
+          'parentProcessId',
+          'creationToken',
+          'classification',
+        ]) ||
+      !acceptedNames.has(entry.name) ||
+      ![
+        'bounded-powershell',
+        'filesystem-authentication',
+        'native-build-node',
+        'native-clean-node',
+        'native-compiler',
+        'native-linker',
+        'native-probe-node',
+        'other-task-descendant',
+        'taskkill-tree',
+        'visual-studio-authentication',
+      ].includes(entry.role) ||
+      !Number.isSafeInteger(entry.processId) ||
+      entry.processId <= 0 ||
+      !Number.isSafeInteger(entry.parentProcessId) ||
+      entry.parentProcessId < 0 ||
+      typeof entry.creationToken !== 'string' ||
+      !/^[1-9][0-9]{0,18}$/.test(entry.creationToken) ||
+      ![
+        'ambiguous',
+        'moxley-command',
+        'task-rooted',
+      ].includes(entry.classification)
+    ) {
+      return { confirmed: false, processes: [] };
+    }
+    processes.push(Object.freeze({
+      name: entry.name,
+      role: entry.role,
+      processId: entry.processId,
+      parentProcessId: entry.parentProcessId,
+      creationToken: entry.creationToken,
+      classification: entry.classification,
+    }));
+  }
+  return { confirmed: true, processes };
+}
+
+async function entryKind(target) {
+  try {
+    const metadata = await fsp.lstat(target);
+    if (metadata.isSymbolicLink()) return 'symbolic-link';
+    if (metadata.isFile()) return 'file';
+    if (metadata.isDirectory()) return 'directory';
+    return 'other';
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return 'absent';
+    return 'unknown';
+  }
+}
+
+function inventoryPipe(pipeName) {
+  return new Promise((resolve) => {
     let settled = false;
-    const timeout = setTimeout(() => child.kill(), PROCESS_TIMEOUT_MS);
-    child.once('error', reject);
-    child.stdout.on('data', (chunk) => {
-      stdoutLength += chunk.length;
-      if (stdoutLength > MAX_OUTPUT_BYTES) child.kill();
-      else stdout.push(chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      stderrLength += chunk.length;
-      if (stderrLength > MAX_OUTPUT_BYTES) child.kill();
-      else stderr.push(chunk);
-    });
-    child.once('close', (code, signal) => {
+    let socket;
+    let timer;
+    function finish(status) {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
-      if (stdoutLength > MAX_OUTPUT_BYTES || stderrLength > MAX_OUTPUT_BYTES) {
-        reject(new Error('bounded test subprocess output exceeded'));
-        return;
+      clearTimeout(timer);
+      if (socket !== undefined) {
+        socket.removeAllListeners();
+        socket.destroy();
       }
-      resolve({
-        code,
-        signal,
-        stdout: Buffer.concat(stdout),
-        stderr: Buffer.concat(stderr),
-      });
+      resolve(status);
+    }
+    try {
+      socket = net.connect(pipeName);
+    } catch {
+      finish('unknown');
+      return;
+    }
+    timer = setTimeout(() => finish('unknown'), 1_000);
+    socket.once('connect', () => finish('active'));
+    socket.once('error', (error) => {
+      finish(error && error.code === 'ENOENT' ? 'absent' : 'unknown');
     });
   });
+}
+
+async function inventoryRepositoryState() {
+  let identity;
+  try {
+    identity = await buildTest.repositoryLeaseIdentity();
+  } catch {
+    return Object.freeze({
+      filesystemEvidenceConfirmed: false,
+      artifact: 'unknown',
+      receipt: 'unknown',
+      lock: 'unknown',
+      stagingCount: 0,
+      releaseEntryCount: 0,
+      pipe: 'unknown',
+      processEvidenceConfirmed: false,
+      taskOwnedProcessCount: 0,
+      taskOwnedProcessNames: Object.freeze([]),
+    });
+  }
+  const artifact = await entryKind(identity.paths.artifact);
+  const receipt = await entryKind(identity.paths.receipt);
+  const lock = await entryKind(identity.paths.lock);
+  let releaseEntryCount = 0;
+  let stagingCount = 0;
+  let releaseRead = true;
+  try {
+    const entries = await fsp.readdir(identity.paths.release);
+    releaseEntryCount = entries.length;
+    stagingCount = entries.filter((name) =>
+      name.startsWith(STAGING_PREFIX)).length;
+  } catch (error) {
+    if (!(error && error.code === 'ENOENT')) releaseRead = false;
+  }
+  const pipe = await inventoryPipe(identity.pipeName);
+  const processEvidence = await captureCandidateProcesses();
+  const taskOwnedProcesses = processEvidence.processes.filter(
+    (entry) => !ambiguousProcessBaseline.has(processEvidenceKey(entry)),
+  );
+  const taskOwnedProcessNames = [...new Set(
+    taskOwnedProcesses.map((entry) => entry.role),
+  )].sort();
+  return Object.freeze({
+    filesystemEvidenceConfirmed:
+      releaseRead && ![artifact, receipt, lock].includes('unknown'),
+    artifact,
+    receipt,
+    lock,
+    stagingCount,
+    releaseEntryCount,
+    pipe,
+    processEvidenceConfirmed: processEvidence.confirmed,
+    taskOwnedProcessCount: taskOwnedProcesses.length,
+    taskOwnedProcessNames: Object.freeze(taskOwnedProcessNames),
+  });
+}
+
+async function inventoryPromotionScenario(result) {
+  const repository = await inventoryRepositoryState();
+  return Object.freeze({
+    artifact: await entryKind(result.paths.artifact),
+    receipt: await entryKind(result.paths.receipt),
+    lock: await entryKind(result.paths.lock),
+    staging: await entryKind(result.paths.staging),
+    pipe: repository.pipe,
+    processEvidenceConfirmed: repository.processEvidenceConfirmed,
+    taskOwnedProcessCount: repository.taskOwnedProcessCount,
+    taskOwnedProcessNames: repository.taskOwnedProcessNames,
+  });
+}
+
+function inventorySupportsCleanup(inventory) {
+  return (
+    inventory.filesystemEvidenceConfirmed === true &&
+    inventory.pipe === 'absent' &&
+    inventory.processEvidenceConfirmed === true &&
+    inventory.taskOwnedProcessCount === 0
+  );
+}
+
+async function recordUncertainProcessDisposition(disposition) {
+  const inventory = await inventoryRepositoryState();
+  lastUncertainInventory = inventory;
+  if (
+    disposition.disposition === SUBPROCESS_CODES.timeout ||
+    disposition.disposition === SUBPROCESS_CODES.termination ||
+    disposition.terminationConfirmed !== true ||
+    !inventorySupportsCleanup(inventory)
+  ) {
+    uncertainRepositoryState = true;
+  }
+}
+
+function boundedSupervisorFailure(error) {
+  const code = Object.values(SUBPROCESS_CODES).includes(error?.code)
+    ? error.code
+    : SUBPROCESS_CODES.termination;
+  const reason = SUBPROCESS_REASONS.includes(error?.reason)
+    ? error.reason
+    : 'SUBPROCESS_TERMINATION_NOT_CONFIRMED';
+  const causeReason = SUBPROCESS_REASONS.includes(error?.cause?.reason)
+    ? error.cause.reason
+    : null;
+  return {
+    ok: false,
+    disposition: code,
+    reason,
+    causeReason,
+    terminationConfirmed: error?.terminationConfirmed === true,
+    code: null,
+    signal: null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  };
+}
+
+function boundedCompletedProcess(result) {
+  if (result.code === 0 && result.signal === null) {
+    return {
+      ...result,
+      ok: true,
+      disposition: 'SUBPROCESS_SUCCEEDED',
+      reason: null,
+      causeReason: null,
+      terminationConfirmed: true,
+    };
+  }
+  if (typeof result.signal === 'string' && result.signal.length !== 0) {
+    return {
+      ...result,
+      ok: false,
+      disposition: SUBPROCESS_CODES.exit,
+      reason: 'SUBPROCESS_SIGNALLED_EXIT',
+      causeReason: null,
+      terminationConfirmed: true,
+    };
+  }
+  if (Number.isInteger(result.code) && result.code !== 0) {
+    return {
+      ...result,
+      ok: false,
+      disposition: SUBPROCESS_CODES.exit,
+      reason: 'SUBPROCESS_NONZERO_EXIT',
+      causeReason: null,
+      terminationConfirmed: true,
+    };
+  }
+  return {
+    ok: false,
+    disposition: SUBPROCESS_CODES.termination,
+    reason: 'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+    causeReason: null,
+    terminationConfirmed: false,
+    code: result.code ?? null,
+    signal: result.signal ?? null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  };
+}
+
+async function runProcess(file, arguments_, options = {}) {
+  let disposition;
+  try {
+    const result = await buildTest.runProcess(file, arguments_, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdin: options.stdin,
+      timeoutMs: HARNESS_PROCESS_TIMEOUT_MS,
+    });
+    disposition = boundedCompletedProcess(result);
+  } catch (error) {
+    disposition = boundedSupervisorFailure(error);
+  }
+  if (
+    disposition.disposition === SUBPROCESS_CODES.timeout ||
+    disposition.disposition === SUBPROCESS_CODES.termination
+  ) {
+    await recordUncertainProcessDisposition(disposition);
+  }
+  return disposition;
 }
 
 function runNodeScript(script, extraArguments = []) {
@@ -132,6 +685,10 @@ function parseCanonicalOutput(bytes) {
 }
 
 function assertBoundedFailure(result) {
+  assert.equal(result.ok, false);
+  assert.equal(result.disposition, SUBPROCESS_CODES.exit);
+  assert.equal(result.reason, 'SUBPROCESS_NONZERO_EXIT');
+  assert.equal(result.terminationConfirmed, true);
   assert.notEqual(result.code, 0);
   assert.equal(result.signal, null);
   assert.equal(result.stdout.length, 0);
@@ -141,6 +698,113 @@ function assertBoundedFailure(result) {
   assert.equal(stderr.indexOf('\n'), stderr.length - 1);
   assert.equal(stderr.length <= 241, true);
   assert.doesNotMatch(stderr, /[A-Za-z]:\\/);
+}
+
+function assertBoundedSuccess(result) {
+  assert.equal(result.ok, true);
+  assert.equal(result.disposition, 'SUBPROCESS_SUCCEEDED');
+  assert.equal(result.reason, null);
+  assert.equal(result.causeReason, null);
+  assert.equal(result.terminationConfirmed, true);
+  assert.equal(result.code, 0);
+  assert.equal(result.signal, null);
+}
+
+function assertHarnessDispositionMatrix() {
+  const errorCases = [
+    {
+      code: SUBPROCESS_CODES.spawn,
+      reason: 'SUBPROCESS_SPAWN_ERROR',
+      terminationConfirmed: false,
+    },
+    {
+      code: SUBPROCESS_CODES.timeout,
+      reason: 'SUBPROCESS_TIMEOUT',
+      terminationConfirmed: true,
+    },
+    {
+      code: SUBPROCESS_CODES.output,
+      reason: 'SUBPROCESS_STDOUT_LIMIT',
+      terminationConfirmed: true,
+    },
+    {
+      code: SUBPROCESS_CODES.output,
+      reason: 'SUBPROCESS_STDERR_LIMIT',
+      terminationConfirmed: true,
+    },
+    {
+      code: SUBPROCESS_CODES.termination,
+      reason: 'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+      terminationConfirmed: false,
+      cause: Object.freeze({ reason: 'SUBPROCESS_EXIT_WITHOUT_CLOSE' }),
+    },
+    {
+      code: SUBPROCESS_CODES.termination,
+      reason: 'SUBPROCESS_TERMINATION_TOOL_FAILED',
+      terminationConfirmed: false,
+      cause: Object.freeze({ reason: 'SUBPROCESS_STDOUT_LIMIT' }),
+    },
+  ];
+  for (const expected of errorCases) {
+    const actual = boundedSupervisorFailure(Object.freeze(expected));
+    assert.equal(actual.ok, false);
+    assert.equal(actual.disposition, expected.code);
+    assert.equal(actual.reason, expected.reason);
+    assert.equal(
+      actual.causeReason,
+      expected.cause?.reason ?? null,
+    );
+    assert.equal(
+      actual.terminationConfirmed,
+      expected.terminationConfirmed,
+    );
+    assert.equal(actual.code, null);
+    assert.equal(typeof actual.disposition, 'string');
+    assert.equal(typeof actual.reason, 'string');
+  }
+
+  const completedCases = [
+    {
+      result: {
+        code: 23,
+        signal: null,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+      },
+      reason: 'SUBPROCESS_NONZERO_EXIT',
+    },
+    {
+      result: {
+        code: null,
+        signal: 'SIGTERM',
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+      },
+      reason: 'SUBPROCESS_SIGNALLED_EXIT',
+    },
+  ];
+  for (const expected of completedCases) {
+    const actual = boundedCompletedProcess(expected.result);
+    assert.equal(actual.ok, false);
+    assert.equal(actual.disposition, SUBPROCESS_CODES.exit);
+    assert.equal(actual.reason, expected.reason);
+    assert.equal(actual.terminationConfirmed, true);
+    assert.equal(typeof actual.disposition, 'string');
+    assert.equal(typeof actual.reason, 'string');
+  }
+
+  const unexplainedNull = boundedCompletedProcess({
+    code: null,
+    signal: null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  });
+  assert.equal(unexplainedNull.ok, false);
+  assert.equal(unexplainedNull.disposition, SUBPROCESS_CODES.termination);
+  assert.equal(
+    unexplainedNull.reason,
+    'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+  );
 }
 
 async function releaseEntries() {
@@ -204,7 +868,7 @@ async function gitTrackedCFiles() {
     ['ls-files', '--cached', '--others', '--exclude-standard', '*.c'],
     { cwd: REPOSITORY_ROOT },
   );
-  assert.equal(result.code, 0);
+  assertBoundedSuccess(result);
   assert.equal(result.stderr.length, 0);
   const candidates = result.stdout
     .toString('utf8')
@@ -259,6 +923,22 @@ describe(
   () => {
     before(async () => {
       await assertRepositoryGeneratedStateAbsent();
+      const baseline = await captureCandidateProcesses();
+      assert.equal(
+        baseline.confirmed,
+        true,
+        'bounded task-owned process baseline must be available',
+      );
+      assert.equal(
+        baseline.processes.every(
+          (entry) => entry.classification === 'ambiguous',
+        ),
+        true,
+        'preexisting Moxley or task-rooted processes are not baselineable',
+      );
+      ambiguousProcessBaseline = new Set(
+        baseline.processes.map(processEvidenceKey),
+      );
     });
 
     after(async () => {
@@ -266,23 +946,48 @@ describe(
         await closeServer(liveServer);
         liveServer = null;
       }
+      if (uncertainRepositoryState) {
+        lastUncertainInventory = await inventoryRepositoryState();
+        assert.equal(lastUncertainInventory.filesystemEvidenceConfirmed, true);
+        assert.fail(
+          'Uncertain native subprocess state was inventoried and preserved.',
+        );
+      }
       if (liveLockOwned && (await exists(LOCK))) {
         await fsp.unlink(LOCK);
         liveLockOwned = false;
       }
       if (repositoryBuildOwned) {
         const cleanup = await runNodeScript(CLEAN_SCRIPT);
-        assert.equal(cleanup.code, 0);
+        assertBoundedSuccess(cleanup);
         assert.equal(cleanup.stderr.length, 0);
         repositoryBuildOwned = false;
       }
       for (const root of [...sandboxRoots]) await removeSandbox(root);
       await assertRepositoryGeneratedStateAbsent();
+      const finalInventory = await inventoryRepositoryState();
+      assert.equal(finalInventory.filesystemEvidenceConfirmed, true);
+      assert.equal(finalInventory.artifact, 'absent');
+      assert.equal(finalInventory.receipt, 'absent');
+      assert.equal(finalInventory.lock, 'absent');
+      assert.equal(finalInventory.stagingCount, 0);
+      assert.equal(finalInventory.pipe, 'absent');
+      assert.equal(finalInventory.processEvidenceConfirmed, true);
+      assert.equal(finalInventory.taskOwnedProcessCount, 0);
     });
 
     it(
       'production native source is the single characterized classifier authority',
       async () => {
+        assert.equal(HARNESS_PROCESS_TIMEOUT_MS, 300_000);
+        assert.equal(buildTest.PROCESS_TIMEOUT_MS, 30_000);
+        assert.equal(buildTest.AUTHENTICATION_TIMEOUT_MS, 90_000);
+        assert.equal(buildTest.PROBE_TIMEOUT_MS, 10_000);
+        assert.equal(buildTest.EXIT_CLOSE_GRACE_MS, 5_000);
+        assert.equal(buildTest.TASKKILL_TIMEOUT_MS, 10_000);
+        assert.equal(buildTest.POST_TERMINATION_GRACE_MS, 5_000);
+        assert.equal(buildTest.MAX_PROCESS_OUTPUT_BYTES, 2 * 1024 * 1024);
+        assertHarnessDispositionMatrix();
         assert.deepEqual(await gitTrackedCFiles(), [
           'native/windows-reparse-classifier.c',
         ]);
@@ -353,8 +1058,7 @@ describe(
       'native build creates only the no-replace binary and canonical receipt',
       async () => {
         const result = await runNodeScript(BUILD_SCRIPT);
-        assert.equal(result.code, 0);
-        assert.equal(result.signal, null);
+        assertBoundedSuccess(result);
         assert.equal(result.stderr.length, 0);
         const output = parseCanonicalOutput(result.stdout);
         assert.deepEqual(Object.keys(output), [
@@ -510,38 +1214,94 @@ describe(
     it(
       'handled pre-promotion failure removes staging and lock without final output',
       async () => {
-        const sandbox = await createSandbox();
-        const result = await buildTest.exercisePromotionScenario(
-          sandbox,
-          'pre',
-        );
-        assert.equal(result.failed, true);
-        assert.equal(result.code, 'MOXLEY_NATIVE_BUILD_INJECTED_FAILURE');
-        assert.equal(result.observations.leaseClosed, true);
-        assert.equal(await exists(result.paths.artifact), false);
-        assert.equal(await exists(result.paths.receipt), false);
-        assert.equal(await exists(result.paths.staging), false);
-        assert.equal(await exists(result.paths.lock), false);
-        await removeSandbox(sandbox);
+        const cases = [
+          {
+            mode: 'pre',
+            code: 'MOXLEY_NATIVE_BUILD_INJECTED_FAILURE',
+            reason: null,
+            artifact: 'absent',
+            receipt: 'absent',
+            staging: 'absent',
+            lock: 'absent',
+          },
+          {
+            mode: 'termination-unconfirmed-pre',
+            code: SUBPROCESS_CODES.termination,
+            reason: 'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+            causeReason: 'SUBPROCESS_TIMEOUT',
+            artifact: 'absent',
+            receipt: 'absent',
+            staging: 'directory',
+            lock: 'file',
+          },
+        ];
+        for (const expected of cases) {
+          const sandbox = await createSandbox();
+          const result = await buildTest.exercisePromotionScenario(
+            sandbox,
+            expected.mode,
+          );
+          assert.equal(result.failed, true);
+          assert.equal(result.code, expected.code);
+          if (expected.reason !== null) {
+            assert.equal(result.reason, expected.reason);
+            assert.equal(result.terminationConfirmed, false);
+            assert.equal(result.causeReason, expected.causeReason);
+          }
+          assert.equal(result.observations.leaseClosed, true);
+          const inventory = await inventoryPromotionScenario(result);
+          assert.equal(inventory.artifact, expected.artifact);
+          assert.equal(inventory.receipt, expected.receipt);
+          assert.equal(inventory.staging, expected.staging);
+          assert.equal(inventory.lock, expected.lock);
+          assert.equal(inventory.pipe, 'absent');
+          assert.equal(inventory.processEvidenceConfirmed, true);
+          assert.equal(inventory.taskOwnedProcessCount, 0);
+          await removeSandbox(sandbox);
+        }
       },
     );
 
     it(
       'handled post-promotion failure preserves generated evidence for explicit clean',
       async () => {
-        const sandbox = await createSandbox();
-        const result = await buildTest.exercisePromotionScenario(
-          sandbox,
-          'post',
-        );
-        assert.equal(result.failed, true);
-        assert.equal(result.code, 'MOXLEY_NATIVE_BUILD_INJECTED_FAILURE');
-        assert.equal(result.observations.leaseClosed, true);
-        assert.equal(await exists(result.paths.artifact), true);
-        assert.equal(await exists(result.paths.receipt), false);
-        assert.equal(await exists(result.paths.staging), true);
-        assert.equal(await exists(result.paths.lock), true);
-        await removeSandbox(sandbox);
+        const cases = [
+          {
+            mode: 'post',
+            code: 'MOXLEY_NATIVE_BUILD_INJECTED_FAILURE',
+            reason: null,
+          },
+          {
+            mode: 'termination-unconfirmed-post',
+            code: SUBPROCESS_CODES.termination,
+            reason: 'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+            causeReason: 'SUBPROCESS_TIMEOUT',
+          },
+        ];
+        for (const expected of cases) {
+          const sandbox = await createSandbox();
+          const result = await buildTest.exercisePromotionScenario(
+            sandbox,
+            expected.mode,
+          );
+          assert.equal(result.failed, true);
+          assert.equal(result.code, expected.code);
+          if (expected.reason !== null) {
+            assert.equal(result.reason, expected.reason);
+            assert.equal(result.terminationConfirmed, false);
+            assert.equal(result.causeReason, expected.causeReason);
+          }
+          assert.equal(result.observations.leaseClosed, true);
+          const inventory = await inventoryPromotionScenario(result);
+          assert.equal(inventory.artifact, 'file');
+          assert.equal(inventory.receipt, 'absent');
+          assert.equal(inventory.staging, 'directory');
+          assert.equal(inventory.lock, 'file');
+          assert.equal(inventory.pipe, 'absent');
+          assert.equal(inventory.processEvidenceConfirmed, true);
+          assert.equal(inventory.taskOwnedProcessCount, 0);
+          await removeSandbox(sandbox);
+        }
       },
     );
 
@@ -552,8 +1312,7 @@ describe(
           await runNodeScript(CLEAN_SCRIPT, ['unexpected']),
         );
         const clean = await runNodeScript(CLEAN_SCRIPT);
-        assert.equal(clean.code, 0);
-        assert.equal(clean.signal, null);
+        assertBoundedSuccess(clean);
         assert.equal(clean.stderr.length, 0);
         assert.deepEqual(parseCanonicalOutput(clean.stdout), {
           status: 'clean',
@@ -565,8 +1324,7 @@ describe(
         repositoryBuildOwned = false;
         await assertRepositoryGeneratedStateAbsent();
         const second = await runNodeScript(CLEAN_SCRIPT);
-        assert.equal(second.code, 0);
-        assert.equal(second.signal, null);
+        assertBoundedSuccess(second);
         assert.equal(second.stderr.length, 0);
         assert.deepEqual(parseCanonicalOutput(second.stdout), {
           status: 'clean',

--- a/test/windows-native-subprocess.test.cjs
+++ b/test/windows-native-subprocess.test.cjs
@@ -7,10 +7,14 @@ const os = require('node:os');
 const path = require('node:path');
 
 const WORKER_FLAG = '--moxley-native-subprocess-worker';
-const TIMEOUT_WORKER_NATURAL_MS = 2_000;
-const DIRECT_WORKER_NATURAL_MS = 7_000;
-const DESCENDANT_HOLD_MS = 8_000;
-const INHERITED_PIPE_TIMEOUT_MS = 3_000;
+const TASK_OWNED_TREE_NATURAL_MS = 20_000;
+const INHERITED_DESCENDANT_NATURAL_MS = 2_000;
+const TEST_EXECUTION_TIMEOUT_MS = 1_500;
+const TEST_EXIT_CLOSE_GRACE_MS = 100;
+const TEST_POST_TERMINATION_GRACE_MS = 100;
+const TASK_OWNED_ABSENCE_BOUND_MS = 5_000;
+const WORKER_HANDSHAKE_TIMEOUT_MS = 5_000;
+const TEST_CASE_TIMEOUT_MS = 30_000;
 
 function canonicalJson(value) {
   return `${JSON.stringify(value)}\n`;
@@ -29,8 +33,106 @@ function writeBounded(stream, value) {
   });
 }
 
-async function runWorker(mode) {
-  if (process.argv.length !== 4 || process.argv[2] !== WORKER_FLAG) {
+function waitForSpawn(child) {
+  return new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('spawn', resolve);
+  });
+}
+
+function waitForPipeHeldHandshake(child) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(new Error('WORKER_HANDSHAKE_TIMEOUT')),
+      WORKER_HANDSHAKE_TIMEOUT_MS);
+
+    function removeListeners() {
+      child.removeListener('message', onMessage);
+      child.removeListener('error', onError);
+      child.removeListener('exit', onExit);
+    }
+
+    function finish(error) {
+      clearTimeout(timer);
+      removeListeners();
+      if (error === null) resolve();
+      else reject(error);
+    }
+
+    function onMessage(message) {
+      if (
+        message !== null &&
+        typeof message === 'object' &&
+        !Array.isArray(message) &&
+        JSON.stringify(Object.keys(message)) === JSON.stringify(['status']) &&
+        message.status === 'pipe-held'
+      ) {
+        finish(null);
+      } else {
+        finish(new Error('WORKER_HANDSHAKE_INVALID'));
+      }
+    }
+
+    function onError() {
+      finish(new Error('WORKER_HANDSHAKE_ERROR'));
+    }
+
+    function onExit() {
+      finish(new Error('WORKER_HANDSHAKE_EARLY_EXIT'));
+    }
+
+    child.once('message', onMessage);
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
+}
+
+function waitForParentDisconnect() {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(new Error('PARENT_DISCONNECT_TIMEOUT')),
+      WORKER_HANDSHAKE_TIMEOUT_MS);
+
+    function finish(error) {
+      clearTimeout(timer);
+      process.removeListener('disconnect', onDisconnect);
+      if (error === null) resolve();
+      else reject(error);
+    }
+
+    function onDisconnect() {
+      finish(null);
+    }
+
+    process.once('disconnect', onDisconnect);
+  });
+}
+
+function sendWorkerMessage(message) {
+  if (typeof process.send !== 'function') {
+    throw new Error('WORKER_IPC_UNAVAILABLE');
+  }
+  process.send(message, () => {
+    // Delivery is confirmed by the parent's exact message observation. A
+    // concurrent IPC disconnect must not shorten the descendant's lifetime.
+  });
+}
+
+async function writeWorkerEvidence(evidencePath, evidence) {
+  if (typeof evidencePath !== 'string' || !path.isAbsolute(evidencePath)) {
+    throw new Error('WORKER_EVIDENCE_PATH_INVALID');
+  }
+  await fsp.writeFile(evidencePath, canonicalJson(evidence), {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+}
+
+async function runWorker(mode, evidencePath) {
+  const evidenceMode =
+    mode === 'tree-direct' || mode === 'inherited-pipe-direct';
+  if (
+    process.argv[2] !== WORKER_FLAG ||
+    process.argv.length !== (evidenceMode ? 5 : 4)
+  ) {
     throw new Error('WORKER_ARGUMENTS_INVALID');
   }
 
@@ -48,60 +150,93 @@ async function runWorker(mode) {
     return;
   }
 
-  if (mode === 'timeout') {
-    await delay(TIMEOUT_WORKER_NATURAL_MS);
+  if (mode === 'signal-hold') {
+    await delay(TASK_OWNED_TREE_NATURAL_MS);
     return;
   }
 
   if (mode === 'overflow-stdout' || mode === 'overflow-stderr') {
     const buildModule = require('../scripts/build-windows-native.cjs');
-    const bytes = Buffer.alloc(
-      buildModule.__test.MAX_PROCESS_OUTPUT_BYTES + 1,
-      0x78,
-    );
     const stream = mode === 'overflow-stdout' ? process.stdout : process.stderr;
-    await writeBounded(stream, bytes);
-    return;
-  }
-
-  if (mode === 'inherited-descendant') {
-    await delay(DESCENDANT_HOLD_MS);
+    const peer = mode === 'overflow-stdout' ? process.stderr : process.stdout;
+    await writeBounded(peer, 'bounded-peer-stream\n');
     await writeBounded(
-      process.stdout,
-      canonicalJson({ status: 'descendant-finished' }),
+      stream,
+      Buffer.alloc(buildModule.__test.MAX_PROCESS_OUTPUT_BYTES + 1, 0x78),
     );
+    await delay(TASK_OWNED_TREE_NATURAL_MS);
     return;
   }
 
-  if (mode === 'inherited-direct') {
+  if (mode === 'tree-descendant') {
+    await delay(TASK_OWNED_TREE_NATURAL_MS);
+    return;
+  }
+
+  if (mode === 'tree-direct') {
     const descendant = spawn(
       process.execPath,
-      [__filename, WORKER_FLAG, 'inherited-descendant'],
+      [__filename, WORKER_FLAG, 'tree-descendant'],
       {
-        detached: true,
+        detached: false,
         shell: false,
-        stdio: ['ignore', 'inherit', 'inherit'],
+        stdio: ['ignore', 'ignore', 'ignore'],
         windowsHide: true,
       },
     );
-    await new Promise((resolve, reject) => {
-      descendant.once('error', reject);
-      descendant.once('spawn', resolve);
+    await waitForSpawn(descendant);
+    await writeWorkerEvidence(evidencePath, {
+      kind: 'task-owned-tree',
+      directPid: process.pid,
+      descendantPid: descendant.pid,
+      naturalLifetimeMs: TASK_OWNED_TREE_NATURAL_MS,
+    });
+    await delay(TASK_OWNED_TREE_NATURAL_MS);
+    return;
+  }
+
+  if (mode === 'inherited-pipe-descendant') {
+    process.stdout.once('error', () => {});
+    await writeBounded(process.stdout, 'pipe-held-before-disconnect\n');
+    const disconnected = waitForParentDisconnect();
+    sendWorkerMessage({ status: 'pipe-held' });
+    await disconnected;
+    await delay(INHERITED_DESCENDANT_NATURAL_MS);
+    return;
+  }
+
+  if (mode === 'inherited-pipe-direct') {
+    // IPC proves the descendant reached the retained stdout handle. IPC is
+    // closed before the direct worker exits so only stdout can delay close.
+    const descendant = spawn(
+      process.execPath,
+      [__filename, WORKER_FLAG, 'inherited-pipe-descendant'],
+      {
+        detached: true,
+        shell: false,
+        stdio: ['ignore', process.stdout, 'ignore', 'ipc'],
+        windowsHide: true,
+      },
+    );
+    await waitForSpawn(descendant);
+    await waitForPipeHeldHandshake(descendant);
+    if (!descendant.connected) throw new Error('WORKER_IPC_DISCONNECTED_EARLY');
+    descendant.disconnect();
+    await writeWorkerEvidence(evidencePath, {
+      kind: 'inherited-pipe',
+      directPid: process.pid,
+      descendantPid: descendant.pid,
+      naturalLifetimeMs: INHERITED_DESCENDANT_NATURAL_MS,
     });
     descendant.unref();
-    await writeBounded(
-      process.stdout,
-      canonicalJson({ status: 'descendant-started' }),
-    );
-    await delay(DIRECT_WORKER_NATURAL_MS);
-    return;
+    process.exit(0);
   }
 
   throw new Error('WORKER_MODE_INVALID');
 }
 
 if (process.argv[2] === WORKER_FLAG) {
-  runWorker(process.argv[3]).catch(() => {
+  runWorker(process.argv[3], process.argv[4]).catch(() => {
     process.exitCode = 97;
   });
 } else {
@@ -110,9 +245,12 @@ if (process.argv[2] === WORKER_FLAG) {
   const buildModule = require('../scripts/build-windows-native.cjs');
   const buildTest = buildModule.__test;
   const temporaryRoots = new Set();
+  const taskOwnedPids = new Set();
 
-  function workerArguments(mode) {
-    return [__filename, WORKER_FLAG, mode];
+  function workerArguments(mode, evidencePath) {
+    const arguments_ = [__filename, WORKER_FLAG, mode];
+    if (evidencePath !== undefined) arguments_.push(evidencePath);
+    return arguments_;
   }
 
   async function captureError(promise) {
@@ -124,10 +262,57 @@ if (process.argv[2] === WORKER_FLAG) {
     assert.fail('Expected the subprocess operation to fail.');
   }
 
-  function assertBuildError(error, message) {
+  function assertNoRawProcessData(error, forbiddenValues = []) {
+    for (const key of [
+      'stdout',
+      'stderr',
+      'command',
+      'file',
+      'arguments',
+      'args',
+      'env',
+      'environment',
+      'path',
+      'pid',
+      'errno',
+      'syscall',
+      'spawnargs',
+      'spawnfile',
+    ]) {
+      assert.equal(Object.hasOwn(error, key), false, `unexpected ${key}`);
+    }
+    const serialized = JSON.stringify(error);
+    assert.equal(
+      serialized.includes('MOXLEY_NATIVE_BUILD_SUBPROCESS_FAILED'),
+      false,
+    );
+    for (const value of forbiddenValues) {
+      assert.equal(serialized.includes(String(value)), false);
+    }
+  }
+
+  function assertBuildError(
+    error,
+    { code, message, reason, terminationConfirmed, causeReason },
+    forbiddenValues = [],
+  ) {
     assert.equal(error.name, 'NativeBuildError');
-    assert.equal(error.code, 'MOXLEY_NATIVE_BUILD_SUBPROCESS_FAILED');
+    assert.equal(Object.hasOwn(error, 'code'), true);
+    assert.equal(Object.hasOwn(error, 'reason'), true);
+    assert.equal(Object.hasOwn(error, 'terminationConfirmed'), true);
+    assert.equal(error.code, code);
     assert.equal(error.message, message);
+    assert.equal(error.reason, reason);
+    assert.equal(error.terminationConfirmed, terminationConfirmed);
+    if (causeReason === undefined) {
+      assert.equal(Object.hasOwn(error, 'cause'), false);
+    } else {
+      assert.equal(Object.hasOwn(error, 'cause'), true);
+      assert.equal(Object.isFrozen(error.cause), true);
+      assert.deepEqual(Reflect.ownKeys(error.cause), ['reason']);
+      assert.deepEqual(error.cause, { reason: causeReason });
+    }
+    assertNoRawProcessData(error, forbiddenValues);
   }
 
   function sameIdentity(left, right) {
@@ -166,18 +351,126 @@ if (process.argv[2] === WORKER_FLAG) {
     }
   }
 
+  async function withWorkerEvidence(action) {
+    return withAuthenticatedTemporaryDirectory(async (root) => {
+      const evidencePath = path.join(root, 'worker-evidence.json');
+      try {
+        return await action(evidencePath, root);
+      } finally {
+        try {
+          const evidenceStat = await fsp.lstat(evidencePath);
+          assert.equal(evidenceStat.isFile(), true);
+          assert.equal(evidenceStat.isSymbolicLink(), false);
+          await fsp.unlink(evidencePath);
+        } catch (error) {
+          if (error.code !== 'ENOENT') throw error;
+        }
+      }
+    });
+  }
+
+  async function readWorkerEvidence(root, evidencePath, expectedKind) {
+    const stat = await fsp.lstat(evidencePath);
+    assert.equal(stat.isFile(), true);
+    assert.equal(stat.isSymbolicLink(), false);
+    assert.ok(stat.size > 0 && stat.size <= 1_024);
+    const canonicalRoot = await fsp.realpath(root);
+    const canonicalEvidence = await fsp.realpath(evidencePath);
+    const relative = path.relative(canonicalRoot, canonicalEvidence);
+    assert.notEqual(relative, '');
+    assert.equal(path.isAbsolute(relative), false);
+    assert.equal(relative === '..' || relative.startsWith(`..${path.sep}`), false);
+    const text = await fsp.readFile(canonicalEvidence, 'utf8');
+    const evidence = JSON.parse(text);
+    assert.equal(canonicalJson(evidence), text);
+    assert.deepEqual(Reflect.ownKeys(evidence), [
+      'kind',
+      'directPid',
+      'descendantPid',
+      'naturalLifetimeMs',
+    ]);
+    assert.equal(evidence.kind, expectedKind);
+    for (const pid of [evidence.directPid, evidence.descendantPid]) {
+      assert.equal(Number.isSafeInteger(pid), true);
+      assert.ok(pid > 0);
+      assert.notEqual(pid, process.pid);
+      assert.notEqual(pid, process.ppid);
+      taskOwnedPids.add(pid);
+    }
+    assert.notEqual(evidence.directPid, evidence.descendantPid);
+    assert.equal(Number.isSafeInteger(evidence.naturalLifetimeMs), true);
+    assert.ok(evidence.naturalLifetimeMs > 0);
+    return evidence;
+  }
+
+  function taskOwnedProcessExists(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      if (error.code === 'ESRCH') return false;
+      if (error.code === 'EPERM') return true;
+      throw error;
+    }
+  }
+
+  function assertTaskOwnedProcessAbsent(pid) {
+    assert.equal(taskOwnedProcessExists(pid), false, `process ${pid} remains`);
+    taskOwnedPids.delete(pid);
+  }
+
+  async function waitForTaskOwnedProcessAbsent(pid, timeoutMs) {
+    const started = performance.now();
+    while (taskOwnedProcessExists(pid)) {
+      if (performance.now() - started >= timeoutMs) {
+        assert.fail(`process ${pid} exceeded its independent absence bound`);
+      }
+      await delay(25);
+    }
+    taskOwnedPids.delete(pid);
+  }
+
+  function observeTerminationAttempt(attempts) {
+    return (event) => attempts.push(event);
+  }
+
+  function assertExactTerminationAttempt(event) {
+    assert.equal(Object.isFrozen(event), true);
+    assert.deepEqual(Reflect.ownKeys(event), [
+      'authenticatedExecutable',
+      'canonicalPid',
+      'tree',
+      'force',
+    ]);
+    assert.deepEqual(event, {
+      authenticatedExecutable: true,
+      canonicalPid: true,
+      tree: true,
+      force: true,
+    });
+  }
+
   after(() => {
     assert.equal(temporaryRoots.size, 0);
+    assert.equal(taskOwnedPids.size, 0);
   });
 
   test(
     'production subprocess supervision preserves ordinary zero-exit evidence',
+    { timeout: TEST_CASE_TIMEOUT_MS },
     async () => {
       assert.equal(buildTest.PROCESS_TIMEOUT_MS, 30_000);
+      assert.equal(buildTest.AUTHENTICATION_TIMEOUT_MS, 90_000);
+      assert.equal(buildTest.PROBE_TIMEOUT_MS, 10_000);
+      assert.equal(buildTest.EXIT_CLOSE_GRACE_MS, 5_000);
+      assert.equal(buildTest.TASKKILL_TIMEOUT_MS, 10_000);
+      assert.equal(buildTest.POST_TERMINATION_GRACE_MS, 5_000);
       assert.equal(buildTest.MAX_PROCESS_OUTPUT_BYTES, 2 * 1024 * 1024);
+      const attempts = [];
       const result = await buildTest.runProcess(
         process.execPath,
         workerArguments('ordinary'),
+        { onTerminationAttempt: observeTerminationAttempt(attempts) },
       );
       assert.equal(result.code, 0);
       assert.equal(result.signal, null);
@@ -186,25 +479,54 @@ if (process.argv[2] === WORKER_FLAG) {
         canonicalJson({ status: 'ordinary', evidence: 'bounded' }),
       );
       assert.equal(result.stderr.toString('utf8'), 'bounded-stderr\n');
+      assert.deepEqual(attempts, []);
     },
   );
 
   test(
-    'production subprocess success requirement maps nonzero exit to its bounded build error',
+    'production subprocess success requirement distinguishes nonzero exit',
+    { timeout: TEST_CASE_TIMEOUT_MS },
     async () => {
-      const error = await captureError(
-        buildTest.requireProcessSuccess(
-          'Characterized nonzero subprocess',
-          process.execPath,
-          workerArguments('nonzero'),
-        ),
-      );
-      assertBuildError(error, 'Characterized nonzero subprocess failed.');
+      const cases = [
+        {
+          mode: 'nonzero',
+          reason: 'SUBPROCESS_NONZERO_EXIT',
+          options: {},
+        },
+        {
+          mode: 'signal-hold',
+          reason: 'SUBPROCESS_SIGNALLED_EXIT',
+          options: { signalAfterSpawn: true },
+        },
+      ];
+      for (const item of cases) {
+        const attempts = [];
+        const error = await captureError(
+          buildTest.requireProcessSuccess(
+            'Bounded subprocess exit',
+            process.execPath,
+            workerArguments(item.mode),
+            {
+              ...item.options,
+              onTerminationAttempt: observeTerminationAttempt(attempts),
+            },
+          ),
+        );
+        assert.equal(error.terminationConfirmed, true);
+        assertBuildError(error, {
+          code: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_EXIT_FAILED',
+          message: 'Native build subprocess did not exit successfully.',
+          reason: item.reason,
+          terminationConfirmed: true,
+        });
+        assert.deepEqual(attempts, []);
+      }
     },
   );
 
   test(
-    'production subprocess success requirement maps spawn failure to the same bounded build code',
+    'production subprocess success requirement distinguishes spawn failure',
+    { timeout: TEST_CASE_TIMEOUT_MS },
     async () => {
       await withAuthenticatedTemporaryDirectory(async (root) => {
         const absentExecutable = path.join(
@@ -212,77 +534,187 @@ if (process.argv[2] === WORKER_FLAG) {
           'absent-native-subprocess.exe',
         );
         await assert.rejects(fsp.lstat(absentExecutable), { code: 'ENOENT' });
+        const attempts = [];
         const error = await captureError(
           buildTest.requireProcessSuccess(
-            'Characterized absent executable',
+            'Bounded spawn failure',
             absentExecutable,
             [],
+            { onTerminationAttempt: observeTerminationAttempt(attempts) },
           ),
         );
-        assertBuildError(error, 'Characterized absent executable failed.');
-        assert.equal(Object.hasOwn(error, 'cause'), false);
-        assert.equal(Object.hasOwn(error, 'path'), false);
-        assert.equal(Object.hasOwn(error, 'errno'), false);
-        assert.equal(Object.hasOwn(error, 'syscall'), false);
+        assert.equal(error.terminationConfirmed, false);
+        assertBuildError(
+          error,
+          {
+            code: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_SPAWN_FAILED',
+            message: 'Native build subprocess could not be spawned.',
+            reason: 'SUBPROCESS_SPAWN_ERROR',
+            terminationConfirmed: false,
+          },
+          [absentExecutable],
+        );
+        assert.deepEqual(attempts, []);
         await assert.rejects(fsp.lstat(absentExecutable), { code: 'ENOENT' });
       });
     },
   );
 
   test(
-    'production subprocess timeout maps to the same bounded build code',
-    async () => {
-      const error = await captureError(
-        buildTest.requireProcessSuccess(
-          'Characterized timeout subprocess',
-          process.execPath,
-          workerArguments('timeout'),
-          { timeoutMs: 100 },
-        ),
-      );
-      assertBuildError(error, 'Characterized timeout subprocess failed.');
+    'production subprocess timeout confirms bounded task-owned tree termination',
+    { timeout: TEST_CASE_TIMEOUT_MS },
+    async (context) => {
+      await withWorkerEvidence(async (evidencePath, root) => {
+        const attempts = [];
+        const started = performance.now();
+        const error = await captureError(
+          buildTest.runProcess(
+            process.execPath,
+            workerArguments('tree-direct', evidencePath),
+            {
+              timeoutMs: TEST_EXECUTION_TIMEOUT_MS,
+              onTerminationAttempt: observeTerminationAttempt(attempts),
+            },
+          ),
+        );
+        const settlementElapsedMs = performance.now() - started;
+        const evidence = await readWorkerEvidence(
+          root,
+          evidencePath,
+          'task-owned-tree',
+        );
+        assert.equal(attempts.length, 1);
+        assertExactTerminationAttempt(attempts[0]);
+        assert.equal(error.terminationConfirmed, true);
+        assertBuildError(
+          error,
+          {
+            code: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_TIMED_OUT',
+            message: 'Native build subprocess exceeded its execution bound.',
+            reason: 'SUBPROCESS_TIMEOUT',
+            terminationConfirmed: true,
+          },
+          [evidencePath, evidence.directPid, evidence.descendantPid],
+        );
+        assert.ok(
+          settlementElapsedMs >= TEST_EXECUTION_TIMEOUT_MS - 25,
+        );
+        assert.ok(
+          evidence.naturalLifetimeMs > TEST_EXECUTION_TIMEOUT_MS * 10,
+        );
+        assert.ok(settlementElapsedMs < evidence.naturalLifetimeMs);
+        assertTaskOwnedProcessAbsent(evidence.directPid);
+        assertTaskOwnedProcessAbsent(evidence.descendantPid);
+        context.diagnostic(
+          canonicalJson({
+            executionTimeoutMs: TEST_EXECUTION_TIMEOUT_MS,
+            naturalLifetimeMs: evidence.naturalLifetimeMs,
+            settlementElapsedMs:
+              Math.round(settlementElapsedMs * 1000) / 1000,
+            exactTreeAttemptConfirmed: true,
+            directAbsent: true,
+            descendantAbsent: true,
+          }).trimEnd(),
+        );
+      });
     },
   );
 
   test(
-    'production subprocess output overflow maps to the same bounded build code',
+    'production subprocess output overflow distinguishes stdout and stderr',
+    { timeout: TEST_CASE_TIMEOUT_MS },
     async () => {
-      for (const stream of ['stdout', 'stderr']) {
-        const label = `Characterized ${stream} overflow`;
+      const cases = [
+        { mode: 'overflow-stdout', reason: 'SUBPROCESS_STDOUT_LIMIT' },
+        { mode: 'overflow-stderr', reason: 'SUBPROCESS_STDERR_LIMIT' },
+      ];
+      for (const item of cases) {
+        const attempts = [];
         const error = await captureError(
-          buildTest.requireProcessSuccess(
-            label,
+          buildTest.runProcess(
             process.execPath,
-            workerArguments(`overflow-${stream}`),
+            workerArguments(item.mode),
+            { onTerminationAttempt: observeTerminationAttempt(attempts) },
           ),
         );
-        assertBuildError(error, `${label} failed.`);
+        assert.equal(attempts.length, 1);
+        assertExactTerminationAttempt(attempts[0]);
+        assert.equal(error.terminationConfirmed, true);
+        assertBuildError(error, {
+          code: 'MOXLEY_NATIVE_BUILD_SUBPROCESS_OUTPUT_LIMIT',
+          message: 'Native build subprocess exceeded its output bound.',
+          reason: item.reason,
+          terminationConfirmed: true,
+        });
       }
     },
   );
 
   test(
-    'production subprocess timeout is not a true deadline while a descendant retains inherited pipes',
+    'production subprocess exit-without-close fails boundedly with termination unconfirmed evidence',
+    { timeout: TEST_CASE_TIMEOUT_MS },
     async (context) => {
-      const started = performance.now();
-      const error = await captureError(
-        buildTest.runProcess(
-          process.execPath,
-          workerArguments('inherited-direct'),
-          { timeoutMs: INHERITED_PIPE_TIMEOUT_MS },
-        ),
-      );
-      const elapsedMs = performance.now() - started;
-      assertBuildError(error, 'A bounded native build subprocess failed.');
-      assert.ok(elapsedMs >= 6_000, `settled too early: ${elapsedMs}`);
-      assert.ok(elapsedMs < 20_000, `settled too late: ${elapsedMs}`);
-      context.diagnostic(
-        canonicalJson({
-          nominalTimeoutMs: INHERITED_PIPE_TIMEOUT_MS,
-          descendantNaturalLifetimeMs: DESCENDANT_HOLD_MS,
-          settlementElapsedMs: Math.round(elapsedMs * 1000) / 1000,
-        }).trimEnd(),
-      );
+      await withWorkerEvidence(async (evidencePath, root) => {
+        const attempts = [];
+        const started = performance.now();
+        const error = await captureError(
+          buildTest.runProcess(
+            process.execPath,
+            workerArguments('inherited-pipe-direct', evidencePath),
+            {
+              exitCloseGraceMs: TEST_EXIT_CLOSE_GRACE_MS,
+              postTerminationGraceMs: TEST_POST_TERMINATION_GRACE_MS,
+              onTerminationAttempt: observeTerminationAttempt(attempts),
+            },
+          ),
+        );
+        const settlementElapsedMs = performance.now() - started;
+        const evidence = await readWorkerEvidence(
+          root,
+          evidencePath,
+          'inherited-pipe',
+        );
+        assert.deepEqual(attempts, []);
+        assert.equal(error.terminationConfirmed, false);
+        assertBuildError(
+          error,
+          {
+            code:
+              'MOXLEY_NATIVE_BUILD_SUBPROCESS_TERMINATION_UNCONFIRMED',
+            message:
+              'Native build subprocess termination could not be confirmed.',
+            reason: 'SUBPROCESS_TERMINATION_NOT_CONFIRMED',
+            terminationConfirmed: false,
+            causeReason: 'SUBPROCESS_EXIT_WITHOUT_CLOSE',
+          },
+          [evidencePath, evidence.directPid, evidence.descendantPid],
+        );
+        assert.ok(
+          settlementElapsedMs >=
+            TEST_EXIT_CLOSE_GRACE_MS + TEST_POST_TERMINATION_GRACE_MS - 25,
+        );
+        assert.ok(
+          evidence.naturalLifetimeMs >
+            (TEST_EXIT_CLOSE_GRACE_MS + TEST_POST_TERMINATION_GRACE_MS) * 5,
+        );
+        assertTaskOwnedProcessAbsent(evidence.directPid);
+        assert.equal(taskOwnedProcessExists(evidence.descendantPid), true);
+        await waitForTaskOwnedProcessAbsent(
+          evidence.descendantPid,
+          TASK_OWNED_ABSENCE_BOUND_MS,
+        );
+        context.diagnostic(
+          canonicalJson({
+            exitCloseGraceMs: TEST_EXIT_CLOSE_GRACE_MS,
+            postTerminationGraceMs: TEST_POST_TERMINATION_GRACE_MS,
+            naturalLifetimeMs: evidence.naturalLifetimeMs,
+            settlementElapsedMs:
+              Math.round(settlementElapsedMs * 1000) / 1000,
+            taskkillDispatched: false,
+            descendantNaturallyAbsent: true,
+          }).trimEnd(),
+        );
+      });
     },
   );
 }


### PR DESCRIPTION
## Summary

- implement the private native subprocess supervision state machine selected by the merged compatibility contract
- authenticate and bound exact `C:\\Windows\\System32\\taskkill.exe /PID <pid> /T /F` tree termination
- preserve bounded error and cleanup precedence, and repair the subprocess and native-build harnesses

## Verification

- `node --test test/windows-native-subprocess.test.cjs`: 6/6
- `node --test test/windows-native-build.test.cjs`: 10/10
- `npm test`: 66/66 twice
- syntax 15/15; fixtures 19/19; manifests 2/2; Markdown/link checks 3/3
- protected blobs 41/41; exact three-path scope; final cleanup inventory clear